### PR TITLE
Upgrading to tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,17 +30,17 @@ byteorder = "1"
 fnv = "1.0"
 log = "0.4.1"
 lz4-compress = "=0.1.0"
-bb8 = "0.6"
+bb8 = "0.7"
 rand = "0.4.1"
 snap = "0.2.3"
 time = "0.2.16"
-tokio = { version = "0.3", features = ["net", "io-util", "rt", "sync", "macros", "rt-multi-thread"] }
-tokio-rustls = { version = "0.20", optional = true }
+tokio = { version = "1.0", features = ["net", "io-util", "rt", "sync", "macros", "rt-multi-thread"] }
+tokio-rustls = { version = "0.22", optional = true }
 uuid = "0.8.1"
 webpki = { version = "0.21", optional = true }
 
 [dependencies.rustls]
-version = "0.18"
+version = "0.19"
 optional = true
 default-features = false
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -15,8 +15,7 @@ use std::sync::Arc;
 #[cfg(feature = "rust-tls")]
 use tokio_rustls::{TlsConnector as RustlsConnector, client::TlsStream as RustlsStream};
 use std::io;
-use tokio::io::{AsyncWriteExt, ReadBuf};
-use tokio::prelude::*;
+use tokio::io::{AsyncWriteExt, AsyncWrite, AsyncRead, ReadBuf};
 use std::task::Context;
 use tokio::macros::support::{Pin, Poll};
 use std::io::Error;
@@ -103,8 +102,8 @@ impl CDRSTransport for TransportTcp {
         })
     }
 
-    async fn close(&mut self, close: net::Shutdown) -> io::Result<()> {
-        self.tcp.shutdown(close)
+    async fn close(&mut self, _close: net::Shutdown) -> io::Result<()> {
+        self.tcp.shutdown().await
     }
 
     fn is_alive(&self) -> bool {


### PR DESCRIPTION
Looks like updating to tokio 1.0 is not that complicated. 
I have a bunch of tests failing but looks like its cause of my local setup. 
I am new to rust and tokio. So not very sure about this change.
```

failures:

---- frame::events::server_event::status_change_down stdout ----
thread 'frame::events::server_event::status_change_down' panicked at 'assertion failed: `(left == right)`
  left: `"127.0.0.1:1"`,
 right: `"V4(127.0.0.1:1)"`', src/frame/events.rs:554:17

---- frame::events::server_event::status_change_up stdout ----
thread 'frame::events::server_event::status_change_up' panicked at 'assertion failed: `(left == right)`
  left: `"127.0.0.1:1"`,
 right: `"V4(127.0.0.1:1)"`', src/frame/events.rs:535:17

---- frame::events::server_event::topology_change_new_node stdout ----
thread 'frame::events::server_event::topology_change_new_node' panicked at 'assertion failed: `(left == right)`
  left: `"127.0.0.1:1"`,
 right: `"V4(127.0.0.1:1)"`', src/frame/events.rs:496:17

---- frame::events::server_event::topology_change_removed_node stdout ----
thread 'frame::events::server_event::topology_change_removed_node' panicked at 'assertion failed: `(left == right)`
  left: `"127.0.0.1:1"`,
 right: `"V4(127.0.0.1:1)"`', src/frame/events.rs:516:17

---- frame::frame_event::tests::body_res_event stdout ----
thread 'frame::frame_event::tests::body_res_event' panicked at 'assertion failed: `(left == right)`
  left: `"127.0.0.1:1"`,
 right: `"V4(127.0.0.1:1)"`', src/frame/frame_event.rs:41:17


failures:
    frame::events::server_event::status_change_down
    frame::events::server_event::status_change_up
    frame::events::server_event::topology_change_new_node
    frame::events::server_event::topology_change_removed_node
    frame::frame_event::tests::body_res_event

test result: FAILED. 145 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out
```