### PR TITLE
Library improvements to extend connection and session behaviour by client users

### DIFF
--- a/src/cluster/generic_connection_pool.rs
+++ b/src/cluster/generic_connection_pool.rs
@@ -1,16 +1,18 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use crate::transport::CDRSTransport;
+
 /// Generic pool connection that is able to return an
 /// `bb8::Pool` as well as an IP address of a node.
 #[derive(Debug)]
-pub struct ConnectionPool<M: bb8::ManageConnection> {
-    pool: Arc<bb8::Pool<M>>,
+pub struct ConnectionPool<T: CDRSTransport> {
+    pool: Arc<bb8::Pool<T::Manager>>,
     addr: SocketAddr,
 }
 
-impl<M: bb8::ManageConnection> ConnectionPool<M> {
-    pub fn new(pool: bb8::Pool<M>, addr: SocketAddr) -> Self {
+impl<T: CDRSTransport> ConnectionPool<T> {
+    pub fn new(pool: bb8::Pool<T::Manager>, addr: SocketAddr) -> Self {
         ConnectionPool {
             pool: Arc::new(pool),
             addr,
@@ -18,7 +20,7 @@ impl<M: bb8::ManageConnection> ConnectionPool<M> {
     }
 
     /// Returns reference to underlying `bb8::Pool`.
-    pub fn get_pool(&self) -> Arc<bb8::Pool<M>> {
+    pub fn get_pool(&self) -> Arc<bb8::Pool<T::Manager>> {
         self.pool.clone()
     }
 

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -54,7 +54,8 @@ pub trait ConnectionConfig: Send + Sync {
 #[async_trait]
 pub trait GetConnection<
     T: CDRSTransport + Send + Sync + 'static,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
+    E: error::FromCDRSError,
+    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
 >
 {
     /// Returns connection from a load balancer.
@@ -78,13 +79,14 @@ pub trait ResponseCache {
 /// machinery is needed and direct sub traits otherwise.
 pub trait CDRSSession<
     T: CDRSTransport + Unpin + 'static,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
+    E: error::FromCDRSError,
+    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
 >:
     GetCompressor
-    + GetConnection<T, M>
-    + QueryExecutor<T, M>
-    + PrepareExecutor<T, M>
-    + ExecExecutor<T, M>
-    + BatchExecutor<T, M>
+    + GetConnection<T, E, M>
+    + QueryExecutor<T, E, M>
+    + PrepareExecutor<T, E, M>
+    + ExecExecutor<T, E, M>
+    + BatchExecutor<T, E, M>
 {
 }

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -23,11 +23,11 @@ pub use crate::cluster::pager::{ExecPager, PagerState, QueryPager, SessionPager}
 pub use crate::cluster::rustls_connection_pool::{
     new_rustls_pool, RustlsConnectionPool, RustlsConnectionsManager,
 };
+pub use crate::cluster::session::connect;
 pub use crate::cluster::tcp_connection_pool::{
     new_tcp_pool, startup, TcpConnectionPool, TcpConnectionsManager,
 };
 pub use generic_connection_pool::ConnectionPool;
-pub use crate::cluster::session::connect;
 
 use crate::compression::Compression;
 use crate::frame::{Frame, StreamId};
@@ -51,10 +51,7 @@ pub trait ConnectionConfig: Send + Sync {
 /// `GetConnection` trait provides a unified interface for Session to get a connection
 /// from a load balancer
 #[async_trait]
-pub trait GetConnection<
-    T: CDRSTransport + Send + Sync + 'static,
->
-{
+pub trait GetConnection<T: CDRSTransport + Send + Sync + 'static> {
     /// Returns connection from a load balancer.
     async fn get_connection(&self) -> Option<Arc<ConnectionPool<T>>>;
 }
@@ -74,9 +71,7 @@ pub trait ResponseCache {
 
 /// `CDRSSession` trait wrap ups whole query functionality. Use it only if whole query
 /// machinery is needed and direct sub traits otherwise.
-pub trait CDRSSession<
-    T: CDRSTransport + Unpin + 'static,
->:
+pub trait CDRSSession<T: CDRSTransport + Unpin + 'static>:
     GetCompressor
     + GetConnection<T>
     + QueryExecutor<T>

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -27,13 +27,27 @@ pub use crate::cluster::rustls_connection_pool::{
 pub use crate::cluster::tcp_connection_pool::{
     new_tcp_pool, startup, TcpConnectionPool, TcpConnectionsManager,
 };
-pub(crate) use generic_connection_pool::ConnectionPool;
+pub use generic_connection_pool::ConnectionPool;
+pub use crate::cluster::session::connect;
 
 use crate::compression::Compression;
 use crate::error;
 use crate::frame::{Frame, StreamId};
 use crate::query::{BatchExecutor, ExecExecutor, PrepareExecutor, QueryExecutor};
 use crate::transport::CDRSTransport;
+
+use core::fmt::Debug;
+use std::net::SocketAddr;
+
+/// Generic connection configuration trait that can be used to create user-supplied
+/// connection objects that can be used with the `session::connect()` function.
+#[async_trait]
+pub trait ConnectionConfig: Send + Sync {
+    type ConnectionManager: bb8::ManageConnection;
+    type Error: Debug + Send + 'static;
+
+    async fn connect(&self, addr: SocketAddr) -> Result<bb8::Pool<Self::ConnectionManager>, Self::Error>;
+}
 
 /// `GetConnection` trait provides a unified interface for Session to get a connection
 /// from a load balancer

--- a/src/cluster/pager.rs
+++ b/src/cluster/pager.rs
@@ -9,24 +9,14 @@ use crate::transport::CDRSTransport;
 use crate::types::rows::Row;
 use crate::types::CBytes;
 
-pub struct SessionPager<
-    'a,
-    S: CDRSSession<T> + 'a,
-    T: CDRSTransport + Unpin + 'static,
-> {
+pub struct SessionPager<'a, S: CDRSSession<T> + 'a, T: CDRSTransport + Unpin + 'static> {
     page_size: i32,
     session: &'a mut S,
     transport_type: PhantomData<&'a T>,
     connection_type: PhantomData<&'a T::Manager>,
 }
 
-impl<
-        'a,
-        'b: 'a,
-        S: CDRSSession<T>,
-        T: CDRSTransport + Unpin + 'static,
-    > SessionPager<'a, S, T>
-{
+impl<'a, 'b: 'a, S: CDRSSession<T>, T: CDRSTransport + Unpin + 'static> SessionPager<'a, S, T> {
     pub fn new(session: &'b mut S, page_size: i32) -> SessionPager<'a, S, T> {
         SessionPager {
             session,
@@ -100,10 +90,7 @@ impl<
         }
     }
 
-    pub fn exec(
-        &'a mut self,
-        query: &'a PreparedQuery,
-    ) -> ExecPager<'a, SessionPager<'a, S, T>> {
+    pub fn exec(&'a mut self, query: &'a PreparedQuery) -> ExecPager<'a, SessionPager<'a, S, T>> {
         self.exec_with_pager_state(query, PagerState::new())
     }
 }
@@ -116,12 +103,8 @@ pub struct QueryPager<'a, Q: ToString, P: 'a> {
     consistency: Consistency,
 }
 
-impl<
-        'a,
-        Q: ToString,
-        T: CDRSTransport + Unpin + 'static,
-        S: CDRSSession<T> + Sync + Send,
-    > QueryPager<'a, Q, SessionPager<'a, S, T>>
+impl<'a, Q: ToString, T: CDRSTransport + Unpin + 'static, S: CDRSSession<T> + Sync + Send>
+    QueryPager<'a, Q, SessionPager<'a, S, T>>
 {
     pub async fn next(&mut self) -> error::Result<Vec<Row>> {
         let mut params = QueryParamsBuilder::new()
@@ -172,11 +155,8 @@ pub struct ExecPager<'a, P: 'a> {
     query: &'a PreparedQuery,
 }
 
-impl<
-        'a,
-        T: CDRSTransport + Unpin + 'static,
-        S: CDRSSession<T> + Sync + Send,
-    > ExecPager<'a, SessionPager<'a, S, T>>
+impl<'a, T: CDRSTransport + Unpin + 'static, S: CDRSSession<T> + Sync + Send>
+    ExecPager<'a, SessionPager<'a, S, T>>
 {
     pub async fn next(&mut self) -> error::Result<Vec<Row>> {
         let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);

--- a/src/cluster/rustls_connection_pool.rs
+++ b/src/cluster/rustls_connection_pool.rs
@@ -16,7 +16,7 @@ use crate::frame::{AsBytes, Frame};
 use crate::transport::TransportRustls;
 use std::ops::Deref;
 
-pub type RustlsConnectionPool = ConnectionPool<RustlsConnectionsManager>;
+pub type RustlsConnectionPool = ConnectionPool<TransportRustls>;
 
 /// `bb8::Pool` of SSL-based CDRS connections.
 ///

--- a/src/cluster/session.rs
+++ b/src/cluster/session.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
 use fxhash::FxHashMap;
 use std::iter::Iterator;
+use std::net::SocketAddr;
 use std::ops::Deref;
 use std::sync::Arc;
-use std::net::SocketAddr;
 use tokio::{io::AsyncWriteExt, sync::Mutex};
 
 #[cfg(feature = "unstable-dynamic-cluster")]
@@ -49,9 +49,7 @@ impl<LB> GetCompressor for Session<LB> {
 impl<'a, LB> Session<LB> {
     /// Basing on current session returns new `SessionPager` that can be used
     /// for performing paged queries.
-    pub fn paged<
-        T: CDRSTransport + Unpin + 'static,
-    >(
+    pub fn paged<T: CDRSTransport + Unpin + 'static>(
         &'a mut self,
         page_size: i32,
     ) -> SessionPager<'a, Session<LB>, T>

--- a/src/cluster/session.rs
+++ b/src/cluster/session.rs
@@ -3,6 +3,7 @@ use fxhash::FxHashMap;
 use std::iter::Iterator;
 use std::ops::Deref;
 use std::sync::Arc;
+use std::net::SocketAddr;
 use tokio::{io::AsyncWriteExt, sync::Mutex};
 
 #[cfg(feature = "unstable-dynamic-cluster")]
@@ -10,8 +11,8 @@ use crate::cluster::NodeTcpConfig;
 #[cfg(feature = "rust-tls")]
 use crate::cluster::{new_rustls_pool, ClusterRustlsConfig, RustlsConnectionPool};
 use crate::cluster::{
-    new_tcp_pool, startup, CDRSSession, ClusterTcpConfig, ConnectionPool, GetCompressor,
-    GetConnection, KeyspaceHolder, ResponseCache, TcpConnectionPool,
+    new_tcp_pool, startup, CDRSSession, ClusterTcpConfig, ConnectionConfig, ConnectionPool,
+    GetCompressor, GetConnection, KeyspaceHolder, ResponseCache, TcpConnectionPool,
 };
 use crate::error;
 use crate::load_balancing::LoadBalancingStrategy;
@@ -228,6 +229,41 @@ where
     session.event_stream = Some(Mutex::new(event_stream));
 
     Ok(session)
+}
+
+/// This function uses a user-supplied connection configuration to initialize all the
+/// connections in the session. It can be used to supply your own transport and load
+/// balancing mechanisms in order to support unusual node discovery mechanisms
+/// or configuration needs.
+///
+/// The config object supplied differs from the ClusterTcpConfig and ClusterRustlsConfig
+/// objects in that it is not expected to include an address. Instead the same configuration
+/// will be applied to all connections across the cluster.
+pub async fn connect<C, LB>(
+    config: &C,
+    initial_nodes: &[SocketAddr],
+    mut load_balancing: LB,
+    compression: Compression,
+) -> Result<Session<LB>, C::Error>
+where
+    C: ConnectionConfig,
+    LB: LoadBalancingStrategy<ConnectionPool<C::ConnectionManager>> + Sized,
+{
+    let mut nodes: Vec<Arc<ConnectionPool<C::ConnectionManager>>> = Vec::with_capacity(initial_nodes.len());
+
+    for node in initial_nodes {
+        let pool = config.connect(*node).await?;
+        nodes.push(Arc::new(ConnectionPool::new(pool, *node)));
+    }
+
+    load_balancing.init(nodes);
+
+    Ok(Session {
+        load_balancing: Mutex::new(load_balancing),
+        event_stream: None,
+        responses: Default::default(),
+        compression,
+    })
 }
 
 async fn connect_static<LB>(

--- a/src/cluster/session.rs
+++ b/src/cluster/session.rs
@@ -51,13 +51,14 @@ impl<'a, LB> Session<LB> {
     /// for performing paged queries.
     pub fn paged<
         T: CDRSTransport + Unpin + 'static,
-        M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
+        E: error::FromCDRSError,
+        M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
     >(
         &'a mut self,
         page_size: i32,
-    ) -> SessionPager<'a, M, Session<LB>, T>
+    ) -> SessionPager<'a, E, M, Session<LB>, T>
     where
-        Session<LB>: CDRSSession<T, M>,
+        Session<LB>: CDRSSession<T, E, M>,
     {
         SessionPager::new(self, page_size)
     }
@@ -66,9 +67,10 @@ impl<'a, LB> Session<LB> {
 #[async_trait]
 impl<
         T: CDRSTransport + Send + Sync + 'static,
-        M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
+        E: error::FromCDRSError,
+        M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
         LB: LoadBalancingStrategy<ConnectionPool<M>> + Send + Sync,
-    > GetConnection<T, M> for Session<LB>
+    > GetConnection<T, E, M> for Session<LB>
 {
     async fn get_connection(&self) -> Option<Arc<ConnectionPool<M>>> {
         if cfg!(feature = "unstable-dynamic-cluster") {
@@ -103,9 +105,10 @@ impl<
 impl<
         'a,
         T: CDRSTransport + Unpin + 'static,
-        M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
+        E: error::FromCDRSError,
+        M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
         LB: LoadBalancingStrategy<ConnectionPool<M>> + Send + Sync,
-    > QueryExecutor<T, M> for Session<LB>
+    > QueryExecutor<T, E, M> for Session<LB>
 {
 }
 
@@ -113,9 +116,10 @@ impl<
 impl<
         'a,
         T: CDRSTransport + Unpin + 'static,
+        E: error::FromCDRSError,
         LB: LoadBalancingStrategy<ConnectionPool<M>> + Send + Sync,
-        M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
-    > PrepareExecutor<T, M> for Session<LB>
+        M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
+    > PrepareExecutor<T, E, M> for Session<LB>
 {
 }
 
@@ -123,9 +127,10 @@ impl<
 impl<
         'a,
         T: CDRSTransport + Unpin + 'static,
+        E: error::FromCDRSError,
         LB: LoadBalancingStrategy<ConnectionPool<M>> + Send + Sync,
-        M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
-    > ExecExecutor<T, M> for Session<LB>
+        M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
+    > ExecExecutor<T, E, M> for Session<LB>
 {
 }
 
@@ -133,17 +138,19 @@ impl<
 impl<
         'a,
         T: CDRSTransport + Unpin + 'static,
+        E: error::FromCDRSError,
         LB: LoadBalancingStrategy<ConnectionPool<M>> + Send + Sync,
-        M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
-    > BatchExecutor<T, M> for Session<LB>
+        M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
+    > BatchExecutor<T, E, M> for Session<LB>
 {
 }
 
 impl<
         T: CDRSTransport + Unpin + 'static,
-        M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
+        E: error::FromCDRSError,
+        M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
         LB: LoadBalancingStrategy<ConnectionPool<M>> + Send + Sync,
-    > CDRSSession<T, M> for Session<LB>
+    > CDRSSession<T, E, M> for Session<LB>
 {
 }
 

--- a/src/cluster/tcp_connection_pool.rs
+++ b/src/cluster/tcp_connection_pool.rs
@@ -18,7 +18,7 @@ use crate::transport::{CDRSTransport, TransportTcp};
 use std::ops::Deref;
 
 /// Shortcut for `bb8::Pool` type of TCP-based CDRS connections.
-pub type TcpConnectionPool = ConnectionPool<TcpConnectionsManager>;
+pub type TcpConnectionPool = ConnectionPool<TransportTcp>;
 
 /// `bb8::Pool` of TCP-based CDRS connections.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::error;
+use std::{fmt::Debug, error};
 use std::fmt;
 use std::fmt::Display;
 use std::io;
@@ -102,3 +102,7 @@ impl<'a> From<&'a str> for Error {
         Error::General(err.to_string())
     }
 }
+
+/// Marker trait for error types that can be converted from CDRS errors
+pub trait FromCDRSError: From<Error> + std::error::Error + Send + Sync + Debug + Display + 'static {}
+impl<E> FromCDRSError for E where E: From<Error> + std::error::Error + Send + Sync + Debug + Display + 'static {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
-use std::{fmt::Debug, error};
 use std::fmt;
 use std::fmt::Display;
 use std::io;
 use std::result;
 use std::string::FromUtf8Error;
+use std::{error, fmt::Debug};
 
 use crate::compression::CompressionError;
 use crate::frame::frame_error::CDRSError;
@@ -104,5 +104,11 @@ impl<'a> From<&'a str> for Error {
 }
 
 /// Marker trait for error types that can be converted from CDRS errors
-pub trait FromCDRSError: From<Error> + std::error::Error + Send + Sync + Debug + Display + 'static {}
-impl<E> FromCDRSError for E where E: From<Error> + std::error::Error + Send + Sync + Debug + Display + 'static {}
+pub trait FromCDRSError:
+    From<Error> + std::error::Error + Send + Sync + Debug + Display + 'static
+{
+}
+impl<E> FromCDRSError for E where
+    E: From<Error> + std::error::Error + Send + Sync + Debug + Display + 'static
+{
+}

--- a/src/frame/parser.rs
+++ b/src/frame/parser.rs
@@ -12,13 +12,14 @@ use crate::transport::CDRSTransport;
 use crate::types::data_serialization_types::decode_timeuuid;
 use crate::types::{from_bytes, from_i16_bytes, CStringList, UUID_LEN};
 
-pub async fn from_connection<M, T>(
+pub async fn from_connection<M, E, T>(
     conn: &bb8::PooledConnection<'_, M>,
     compressor: Compression,
 ) -> error::Result<Frame>
 where
     T: CDRSTransport + Unpin + 'static,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
+    E: error::FromCDRSError,
+    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
 {
     parse_frame(conn.deref(), compressor).await
 }

--- a/src/query/batch_executor.rs
+++ b/src/query/batch_executor.rs
@@ -10,9 +10,8 @@ use crate::transport::CDRSTransport;
 use super::utils::{prepare_flags, send_frame};
 
 #[async_trait]
-pub trait BatchExecutor<
-    T: CDRSTransport + Unpin + 'static,
->: GetConnection<T> + GetCompressor + ResponseCache + Sync
+pub trait BatchExecutor<T: CDRSTransport + Unpin + 'static>:
+    GetConnection<T> + GetCompressor + ResponseCache + Sync
 {
     async fn batch_with_params_tw(
         &self,

--- a/src/query/batch_executor.rs
+++ b/src/query/batch_executor.rs
@@ -13,8 +13,9 @@ use super::utils::{prepare_flags, send_frame};
 #[async_trait]
 pub trait BatchExecutor<
     T: CDRSTransport + Unpin + 'static,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
->: GetConnection<T, M> + GetCompressor + ResponseCache + Sync
+    E: error::FromCDRSError,
+    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
+>: GetConnection<T, E, M> + GetCompressor + ResponseCache + Sync
 {
     async fn batch_with_params_tw(
         &self,

--- a/src/query/batch_executor.rs
+++ b/src/query/batch_executor.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use tokio::sync::Mutex;
 
 use crate::cluster::{GetCompressor, GetConnection, ResponseCache};
 use crate::error;
@@ -13,9 +12,7 @@ use super::utils::{prepare_flags, send_frame};
 #[async_trait]
 pub trait BatchExecutor<
     T: CDRSTransport + Unpin + 'static,
-    E: error::FromCDRSError,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
->: GetConnection<T, E, M> + GetCompressor + ResponseCache + Sync
+>: GetConnection<T> + GetCompressor + ResponseCache + Sync
 {
     async fn batch_with_params_tw(
         &self,

--- a/src/query/exec_executor.rs
+++ b/src/query/exec_executor.rs
@@ -10,9 +10,8 @@ use super::utils::{prepare_flags, send_frame};
 use std::ops::Deref;
 
 #[async_trait]
-pub trait ExecExecutor<
-    T: CDRSTransport + Unpin + 'static,
->: GetConnection<T> + GetCompressor + PrepareExecutor<T> + ResponseCache + Sync
+pub trait ExecExecutor<T: CDRSTransport + Unpin + 'static>:
+    GetConnection<T> + GetCompressor + PrepareExecutor<T> + ResponseCache + Sync
 {
     async fn exec_with_params_tw(
         &self,

--- a/src/query/exec_executor.rs
+++ b/src/query/exec_executor.rs
@@ -13,8 +13,9 @@ use std::ops::Deref;
 #[async_trait]
 pub trait ExecExecutor<
     T: CDRSTransport + Unpin + 'static,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
->: GetConnection<T, M> + GetCompressor + PrepareExecutor<T, M> + ResponseCache + Sync
+    E: error::FromCDRSError,
+    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
+>: GetConnection<T, E, M> + GetCompressor + PrepareExecutor<T, E, M> + ResponseCache + Sync
 {
     async fn exec_with_params_tw(
         &self,

--- a/src/query/exec_executor.rs
+++ b/src/query/exec_executor.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use tokio::sync::Mutex;
 
 use crate::cluster::{GetCompressor, GetConnection, ResponseCache};
 use crate::error;
@@ -13,9 +12,7 @@ use std::ops::Deref;
 #[async_trait]
 pub trait ExecExecutor<
     T: CDRSTransport + Unpin + 'static,
-    E: error::FromCDRSError,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
->: GetConnection<T, E, M> + GetCompressor + PrepareExecutor<T, E, M> + ResponseCache + Sync
+>: GetConnection<T> + GetCompressor + PrepareExecutor<T> + ResponseCache + Sync
 {
     async fn exec_with_params_tw(
         &self,

--- a/src/query/prepare_executor.rs
+++ b/src/query/prepare_executor.rs
@@ -1,7 +1,6 @@
 use std::sync::RwLock;
 
 use async_trait::async_trait;
-use tokio::sync::Mutex;
 
 use crate::cluster::{GetCompressor, GetConnection, ResponseCache};
 use crate::error;
@@ -15,9 +14,7 @@ use super::utils::{prepare_flags, send_frame};
 #[async_trait]
 pub trait PrepareExecutor<
     T: CDRSTransport + Unpin + 'static,
-    E: error::FromCDRSError,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
->: GetConnection<T, E, M> + GetCompressor + ResponseCache + Sync
+>: GetConnection<T> + GetCompressor + ResponseCache + Sync
 {
     /// It prepares a query for execution, along with query itself the
     /// method takes `with_tracing` and `with_warnings` flags to get

--- a/src/query/prepare_executor.rs
+++ b/src/query/prepare_executor.rs
@@ -15,8 +15,9 @@ use super::utils::{prepare_flags, send_frame};
 #[async_trait]
 pub trait PrepareExecutor<
     T: CDRSTransport + Unpin + 'static,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
->: GetConnection<T, M> + GetCompressor + ResponseCache + Sync
+    E: error::FromCDRSError,
+    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
+>: GetConnection<T, E, M> + GetCompressor + ResponseCache + Sync
 {
     /// It prepares a query for execution, along with query itself the
     /// method takes `with_tracing` and `with_warnings` flags to get

--- a/src/query/prepare_executor.rs
+++ b/src/query/prepare_executor.rs
@@ -12,9 +12,8 @@ use crate::transport::CDRSTransport;
 use super::utils::{prepare_flags, send_frame};
 
 #[async_trait]
-pub trait PrepareExecutor<
-    T: CDRSTransport + Unpin + 'static,
->: GetConnection<T> + GetCompressor + ResponseCache + Sync
+pub trait PrepareExecutor<T: CDRSTransport + Unpin + 'static>:
+    GetConnection<T> + GetCompressor + ResponseCache + Sync
 {
     /// It prepares a query for execution, along with query itself the
     /// method takes `with_tracing` and `with_warnings` flags to get

--- a/src/query/query_executor.rs
+++ b/src/query/query_executor.rs
@@ -12,8 +12,9 @@ use super::utils::{prepare_flags, send_frame};
 #[async_trait]
 pub trait QueryExecutor<
     T: CDRSTransport + Unpin + 'static,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
->: GetConnection<T, M> + GetCompressor + ResponseCache + Sync
+    E: error::FromCDRSError,
+    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
+>: GetConnection<T, E, M> + GetCompressor + ResponseCache + Sync
 {
     async fn query_with_params_tw<Q: ToString + Send>(
         &self,

--- a/src/query/query_executor.rs
+++ b/src/query/query_executor.rs
@@ -9,9 +9,8 @@ use crate::transport::CDRSTransport;
 use super::utils::{prepare_flags, send_frame};
 
 #[async_trait]
-pub trait QueryExecutor<
-    T: CDRSTransport + Unpin + 'static,
->: GetConnection<T> + GetCompressor + ResponseCache + Sync
+pub trait QueryExecutor<T: CDRSTransport + Unpin + 'static>:
+    GetConnection<T> + GetCompressor + ResponseCache + Sync
 {
     async fn query_with_params_tw<Q: ToString + Send>(
         &self,

--- a/src/query/query_executor.rs
+++ b/src/query/query_executor.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use tokio::sync::Mutex;
 
 use crate::cluster::{GetCompressor, GetConnection, ResponseCache};
 use crate::error;
@@ -12,9 +11,7 @@ use super::utils::{prepare_flags, send_frame};
 #[async_trait]
 pub trait QueryExecutor<
     T: CDRSTransport + Unpin + 'static,
-    E: error::FromCDRSError,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
->: GetConnection<T, E, M> + GetCompressor + ResponseCache + Sync
+>: GetConnection<T> + GetCompressor + ResponseCache + Sync
 {
     async fn query_with_params_tw<Q: ToString + Send>(
         &self,

--- a/src/query/utils.rs
+++ b/src/query/utils.rs
@@ -1,5 +1,3 @@
-use tokio::sync::Mutex;
-
 use crate::cluster::{GetCompressor, GetConnection, ResponseCache};
 use crate::error;
 use crate::frame::frame_result::ResultKind;
@@ -22,16 +20,14 @@ pub fn prepare_flags(with_tracing: bool, with_warnings: bool) -> Vec<Flag> {
     flags
 }
 
-pub async fn send_frame<S: ?Sized, T, E, M>(
+pub async fn send_frame<S: ?Sized, T>(
     sender: &S,
     frame_bytes: Vec<u8>,
     stream_id: StreamId,
 ) -> error::Result<Frame>
 where
-    E: error::FromCDRSError,
-    S: GetConnection<T, E, M> + GetCompressor + ResponseCache,
+    S: GetConnection<T> + GetCompressor + ResponseCache,
     T: CDRSTransport + Unpin + 'static,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
 {
     let compression = sender.get_compressor();
 

--- a/src/query/utils.rs
+++ b/src/query/utils.rs
@@ -22,15 +22,16 @@ pub fn prepare_flags(with_tracing: bool, with_warnings: bool) -> Vec<Flag> {
     flags
 }
 
-pub async fn send_frame<S: ?Sized, T, M>(
+pub async fn send_frame<S: ?Sized, T, E, M>(
     sender: &S,
     frame_bytes: Vec<u8>,
     stream_id: StreamId,
 ) -> error::Result<Frame>
 where
-    S: GetConnection<T, M> + GetCompressor + ResponseCache,
+    E: error::FromCDRSError,
+    S: GetConnection<T, E, M> + GetCompressor + ResponseCache,
     T: CDRSTransport + Unpin + 'static,
-    M: bb8::ManageConnection<Connection = Mutex<T>, Error = error::Error>,
+    M: bb8::ManageConnection<Connection = Mutex<T>, Error = E>,
 {
     let compression = sender.get_compressor();
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -36,6 +36,7 @@ pub trait CDRSTransport: Sized + AsyncRead + AsyncWriteExt + Send + Sync {
 }
 
 /// Default Tcp transport.
+#[derive(Debug)]
 pub struct TransportTcp {
     tcp: TcpStream,
     keyspace_holder: Arc<KeyspaceHolder>,


### PR DESCRIPTION
This is a series of changes that improve the ability to control connection and session behaviour by users of this library. It does this by adding a new 'kind' of session configuration object that knows its own connection pool type and a function in the session module to initialize a session with it.

The use case for this, in my case, is an internal connection pooling mechanism and internal-specific requirements on TLS parameters. These things are also connected to each other and need to work in concert, so it's not enough to simply implement a new LoadBalancer. Note that it is currently at least very difficult, if not impossible, to implement and use a custom connection type or even load balancer from outside the cdrs_tokio codebase due to several traits not being exposed as pub, so even without this I would probably still be submitting a smaller patch to expose some things.

Obviously that's a fairly specific need, but I also think this mechanism would be a good way forward for reshaping the existing session creation mechanisms since it doesn't require an independent config object per connection and can allow you to parameterize more information about the connection in a more convenient way than the plethora of connect_xxx methods that exist now, but I left that for the future as it would be a breaking change. Dynamic connection pool adjustments are also *considerably* simpler with this design, so it might be a path to getting those interfaces implemented without the experimental flag as well.

The following changes are also in this patch set but could probably be broken out into separate PRs if it's too much for this one:
* Many complicated type constraints were removed across the code base in favour of using associated types to express type relationships.
* An authenticator that can be configured at runtime to be either password or no authentication was added -- right now the type of authentication is encoded in type parameters all over the place so it makes it quite difficult to make this a config option in a using program.
* Session connection pools can implement their own error types so long as they implement `From<cdrs_tokio::Error>` so they can convey connection-specific failures.
* CDRSConnection trait methods that aren't used anywhere in the code-base are removed. They are also not really part of the public contract of the crate. At least one of them was doing something completely opposite of what it was documented to do. I would suggest that these methods should be re-designed if they are actually needed and there's no reason to keep the existing versions in.

I apologize for how sprawling these changes are. I have tried to make sure that the changes I'm submitting are connected to what I'm trying to achieve and also be beneficial. As mentioned above, if parts of this should be split off into separate PRs please let me know and I will do my best. I recommend looking at the changes on a commit-basis first if you can.

I also know that it kind of sucks to get a large PR with this much design work already done on it, but I hope I've justified my use-case well enough and I think it would probably be useful to others as well.