### PR TITLE
Exposing variables

### DIFF
--- a/src/cluster/pager.rs
+++ b/src/cluster/pager.rs
@@ -97,7 +97,7 @@ impl<'a, 'b: 'a, S: CdrsSession<T>, T: CdrsTransport + Unpin + 'static> SessionP
 
 pub struct QueryPager<'a, Q: ToString, P: 'a> {
     pager: &'a mut P,
-    pager_state: PagerState,
+    pub pager_state: PagerState,
     query: Q,
     qv: Option<QueryValues>,
     consistency: Consistency,
@@ -196,7 +196,7 @@ impl<'a, T: CdrsTransport + Unpin + 'static, S: CdrsSession<T> + Sync + Send>
 
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct PagerState {
-    cursor: Option<CBytes>,
+    pub cursor: Option<CBytes>,
     has_more_pages: Option<bool>,
 }
 

--- a/src/cluster/pager.rs
+++ b/src/cluster/pager.rs
@@ -97,7 +97,7 @@ impl<'a, 'b: 'a, S: CdrsSession<T>, T: CdrsTransport + Unpin + 'static> SessionP
 
 pub struct QueryPager<'a, Q: ToString, P: 'a> {
     pager: &'a mut P,
-    pub pager_state: PagerState,
+    pager_state: PagerState,
     query: Q,
     qv: Option<QueryValues>,
     consistency: Consistency,
@@ -106,6 +106,10 @@ pub struct QueryPager<'a, Q: ToString, P: 'a> {
 impl<'a, Q: ToString, T: CdrsTransport + Unpin + 'static, S: CdrsSession<T> + Sync + Send>
     QueryPager<'a, Q, SessionPager<'a, S, T>>
 {
+    pub fn into_pager_state(self) -> PagerState {
+        self.pager_state
+    }
+
     pub async fn next(&mut self) -> error::Result<Vec<Row>> {
         let mut params = QueryParamsBuilder::new()
             .consistency(self.consistency)
@@ -158,6 +162,10 @@ pub struct ExecPager<'a, P: 'a> {
 impl<'a, T: CdrsTransport + Unpin + 'static, S: CdrsSession<T> + Sync + Send>
     ExecPager<'a, SessionPager<'a, S, T>>
 {
+    pub fn into_pager_state(self) -> PagerState {
+        self.pager_state
+    }
+
     pub async fn next(&mut self) -> error::Result<Vec<Row>> {
         let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
         if self.pager_state.cursor.is_some() {
@@ -196,7 +204,7 @@ impl<'a, T: CdrsTransport + Unpin + 'static, S: CdrsSession<T> + Sync + Send>
 
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct PagerState {
-    pub cursor: Option<CBytes>,
+    cursor: Option<CBytes>,
     has_more_pages: Option<bool>,
 }
 
@@ -225,5 +233,9 @@ impl PagerState {
 
     pub fn get_cursor(&self) -> Option<CBytes> {
         self.cursor.clone()
+    }
+
+    pub fn into_cursor(self) -> Option<CBytes> {
+        self.cursor
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -562,6 +562,10 @@ impl CBytes {
             Some(bytes) => bytes.is_empty(),
         }
     }
+
+    pub fn into_bytes(self) -> Option<Vec<u8>> {
+        self.bytes
+    }
 }
 
 impl FromCursor for CBytes {


### PR DESCRIPTION
This makes some variables `pub` so I can send the bytes from a paging function to clients which they can send back to retrieve the next page.

Note: I did not expose the `bytes` variable but created a method `into_bytes` so the CBytes can never be created by a user. I don't like the `get_cursor` method on `PagerState` because that uses a `clone` which is unnecessary (in my case).