### PR TITLE
Rename method

### DIFF
--- a/cdrs-tokio/src/cluster/config_rustls.rs
+++ b/cdrs-tokio/src/cluster/config_rustls.rs
@@ -57,6 +57,12 @@ impl NodeRustlsConfigBuilder {
         self
     }
 
+    /// Adds initial node addresses
+    pub fn with_contact_points(mut self, addr: Vec<NodeAddress>) -> Self {
+        self.addrs.extend(addr);
+        self
+    }
+
     /// Finalizes building process
     pub async fn build(self) -> Result<NodeRustlsConfig> {
         // replace with map() when async lambdas become available

--- a/cdrs-tokio/src/cluster/config_rustls.rs
+++ b/cdrs-tokio/src/cluster/config_rustls.rs
@@ -50,8 +50,9 @@ impl NodeRustlsConfigBuilder {
         self
     }
 
-    /// Adds node address.
-    pub fn with_node_address(mut self, addr: NodeAddress) -> Self {
+    /// Adds initial node address (a contact point). Contact points are considered local to the
+    /// driver until a topology refresh occurs.
+    pub fn with_contact_point(mut self, addr: NodeAddress) -> Self {
         self.addrs.push(addr);
         self
     }

--- a/cdrs-tokio/src/cluster/config_tcp.rs
+++ b/cdrs-tokio/src/cluster/config_tcp.rs
@@ -57,6 +57,12 @@ impl NodeTcpConfigBuilder {
         self
     }
 
+    /// Adds initial node addresses
+    pub fn with_contact_points(mut self, addr: Vec<NodeAddress>) -> Self {
+        self.addrs.extend(addr);
+        self
+    }
+
     /// Finalizes building process
     pub async fn build(self) -> Result<NodeTcpConfig> {
         // replace with map() when async lambdas become available


### PR DESCRIPTION
The other builder method for adding a contact point is called `with_contact_point` so I renamed this one. 

For my usecase it would also be useful to be able to pass a `Vec<String>` of node addresses in and have them all added in one go. Let me know if you are interested in doing that in this PR. 