### PR TITLE
Make invalid states unrepresentable in QueryParams

### DIFF
--- a/cassandra-protocol/src/frame/frame_query.rs
+++ b/cassandra-protocol/src/frame/frame_query.rs
@@ -1,6 +1,6 @@
 use crate::consistency::Consistency;
 use crate::frame::*;
-use crate::query::{Query, QueryFlags, QueryParams, QueryValues};
+use crate::query::{Query, QueryParams, QueryValues};
 use crate::types::*;
 use std::io::Cursor;
 
@@ -19,45 +19,17 @@ impl BodyReqQuery {
         query: String,
         consistency: Consistency,
         values: Option<QueryValues>,
-        with_names: Option<bool>,
+        with_names: bool,
         page_size: Option<i32>,
         paging_state: Option<CBytes>,
         serial_consistency: Option<Consistency>,
         timestamp: Option<i64>,
         is_idempotent: bool,
     ) -> BodyReqQuery {
-        // query flags
-        let mut flags = QueryFlags::empty();
-
-        if values.is_some() {
-            flags.insert(QueryFlags::VALUE);
-        }
-
-        if with_names.unwrap_or(false) {
-            flags.insert(QueryFlags::WITH_NAMES_FOR_VALUES);
-        }
-
-        if page_size.is_some() {
-            flags.insert(QueryFlags::PAGE_SIZE);
-        }
-
-        if paging_state.is_some() {
-            flags.insert(QueryFlags::WITH_PAGING_STATE);
-        }
-
-        if serial_consistency.is_some() {
-            flags.insert(QueryFlags::WITH_SERIAL_CONSISTENCY);
-        }
-
-        if timestamp.is_some() {
-            flags.insert(QueryFlags::WITH_DEFAULT_TIMESTAMP);
-        }
-
         BodyReqQuery {
             query: CStringLong::new(query),
             query_params: QueryParams {
                 consistency,
-                flags,
                 with_names,
                 values,
                 page_size,
@@ -87,7 +59,7 @@ impl Frame {
         query: String,
         consistency: Consistency,
         values: Option<QueryValues>,
-        with_names: Option<bool>,
+        with_names: bool,
         page_size: Option<i32>,
         paging_state: Option<CBytes>,
         serial_consistency: Option<Consistency>,

--- a/cassandra-protocol/src/query/query_params_builder.rs
+++ b/cassandra-protocol/src/query/query_params_builder.rs
@@ -9,7 +9,7 @@ pub struct QueryParamsBuilder {
     consistency: Consistency,
     flags: Option<QueryFlags>,
     values: Option<QueryValues>,
-    with_names: Option<bool>,
+    with_names: bool,
     page_size: Option<i32>,
     paging_state: Option<CBytes>,
     serial_consistency: Option<Consistency>,
@@ -37,12 +37,11 @@ impl QueryParamsBuilder {
 
     /// Sets new query consistency
     pub fn values(mut self, values: QueryValues) -> Self {
-        let with_names = values.has_names();
-        self.with_names = Some(with_names);
+        self.with_names = values.has_names();
         self.values = Some(values);
         self.flags = self.flags.or_else(|| {
             let mut flags = QueryFlags::VALUE;
-            if with_names {
+            if self.with_names {
                 flags.insert(QueryFlags::WITH_NAMES_FOR_VALUES);
             }
             Some(flags)
@@ -51,7 +50,11 @@ impl QueryParamsBuilder {
         self
     }
 
-    builder_opt_field!(with_names, bool);
+    /// Sets the "with names for values" flag
+    pub fn with_names(mut self, with_names: bool) -> Self {
+        self.with_names = with_names;
+        self
+    }
 
     /// Sets new query consistency
     pub fn page_size(mut self, size: i32) -> Self {
@@ -85,7 +88,6 @@ impl QueryParamsBuilder {
     pub fn finalize(self) -> QueryParams {
         QueryParams {
             consistency: self.consistency,
-            flags: self.flags.unwrap_or_default(),
             values: self.values,
             with_names: self.with_names,
             page_size: self.page_size,

--- a/cdrs-tokio/src/cluster/connection_manager.rs
+++ b/cdrs-tokio/src/cluster/connection_manager.rs
@@ -127,7 +127,7 @@ async fn set_keyspace<T: CdrsTransport>(
             format!("USE {}", current_keyspace),
             Default::default(),
             None,
-            None,
+            false,
             None,
             None,
             None,

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,8 @@ understated.
 
 ### Changed
 
+* All `with_name` fields or args in the query API are now `bool` instead of `Option<bool>`
+* `flags` field removed from `QueryParams` (flags are now derived from the other fields at serialization time)
 * Rewritten transport layer for massive performance improvements (including removing `bb8`). This
   involves changing a large portion of public API related to transport and server events.
 * Rewritten event mechanism - now you can subscribe to server events via `create_event_receiver()` in `Session`.


### PR DESCRIPTION
By changing:
* with_names to be `bool` instead of `Option<bool>`
* removing the flags field (flags are now generated at serialization time)

we get a much better UX as many invalid states are no longer possible.