### PR TITLE
Merge ks and table in ColSpec

### DIFF
--- a/cdrs-tokio/src/cluster/session.rs
+++ b/cdrs-tokio/src/cluster/session.rs
@@ -33,7 +33,7 @@ use crate::transport::{CdrsTransport, TransportTcp};
 use cassandra_protocol::compression::Compression;
 use cassandra_protocol::error;
 use cassandra_protocol::events::ServerEvent;
-use cassandra_protocol::frame::frame_result::BodyResResultPrepared;
+use cassandra_protocol::frame::frame_result::{BodyResResultPrepared, TableSpec};
 use cassandra_protocol::frame::{Frame, Serialize};
 use cassandra_protocol::query::utils::prepare_flags;
 use cassandra_protocol::query::{
@@ -321,7 +321,7 @@ impl<
                 keyspace: result
                     .metadata
                     .global_table_spec
-                    .map(|(keyspace, _)| keyspace.as_plain()),
+                    .map(|TableSpec { ks_name, .. }| ks_name.as_plain()),
                 pk_indexes: result.metadata.pk_indexes,
             })
     }


### PR DESCRIPTION
- Merge `ks_name` and `table_name` in `ColSpec` to a struct called `TableSpec` since they will either be both present or both absent.
- Convert the tuples in `RowsMetadata` and `PreparedMetadata` to use the same struct. Using a struct instead of a tuple lets them be accessed with field names instead of indexes.