### PR TITLE
Add frame encode/decode round trip test

### DIFF
--- a/cassandra-protocol/src/frame/frame_auth_challenge.rs
+++ b/cassandra-protocol/src/frame/frame_auth_challenge.rs
@@ -5,7 +5,7 @@ use crate::frame::FromCursor;
 use crate::types::CBytes;
 
 /// Server authentication challenge.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct BodyResAuthChallenge {
     pub data: CBytes,
 }

--- a/cassandra-protocol/src/frame/frame_authenticate.rs
+++ b/cassandra-protocol/src/frame/frame_authenticate.rs
@@ -5,7 +5,7 @@ use crate::frame::FromCursor;
 use crate::types::CString;
 
 /// A server authentication challenge.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct BodyResAuthenticate {
     pub data: CString,
 }

--- a/cassandra-protocol/src/frame/frame_error.rs
+++ b/cassandra-protocol/src/frame/frame_error.rs
@@ -18,7 +18,7 @@ pub type Result = result::Result<Frame, CdrsError>;
 /// from the specification it contains an error code and an error message. Apart of those
 /// depending of type of error it could contain an additional information about an error.
 /// This additional information is represented by `additional_info` property which is `ErrorKind`.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct CdrsError {
     /// `i32` that points to a type of error.
     pub error_code: CInt,
@@ -45,7 +45,7 @@ impl FromCursor for CdrsError {
 /// Additional error info in accordance to
 /// [Cassandra protocol v4]
 /// (<https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec>).
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum AdditionalErrorInfo {
     Server,
     Protocol,
@@ -115,7 +115,7 @@ impl AdditionalErrorInfo {
 /// Additional info about
 /// [unavailable exception]
 /// (<https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec>)
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct UnavailableError {
     /// Consistency level of query.
     pub cl: Consistency,
@@ -140,7 +140,7 @@ impl FromCursor for UnavailableError {
 }
 
 /// Timeout exception during a write request.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct WriteTimeoutError {
     /// Consistency level of query.
     pub cl: Consistency,
@@ -169,7 +169,7 @@ impl FromCursor for WriteTimeoutError {
 }
 
 /// Timeout exception during a read request.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct ReadTimeoutError {
     /// Consistency level of query.
     pub cl: Consistency,
@@ -209,7 +209,7 @@ impl FromCursor for ReadTimeoutError {
 }
 
 /// A non-timeout exception during a read request.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct ReadFailureError {
     /// Consistency level of query.
     pub cl: Consistency,
@@ -253,7 +253,7 @@ impl FromCursor for ReadFailureError {
 }
 
 /// A (user defined) function failed during execution.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct FunctionFailureError {
     /// The keyspace of the failed function.
     pub keyspace: CString,
@@ -279,7 +279,7 @@ impl FromCursor for FunctionFailureError {
 
 /// A non-timeout exception during a write request.
 /// [Read more...](https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L1106)
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct WriteFailureError {
     /// Consistency of the query having triggered the exception.
     pub cl: Consistency,
@@ -348,7 +348,7 @@ impl FromCursor for WriteType {
 
 /// The query attempted to create a keyspace or a table that was already existing.
 /// [Read more...](https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L1140)
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct AlreadyExistsError {
     /// Represents either the keyspace that already exists,
     /// or the keyspace in which the table that already exists is.
@@ -370,7 +370,7 @@ impl FromCursor for AlreadyExistsError {
 /// executed if the provided prepared statement ID is not known by
 /// this host. [Read more...]
 /// (<https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec>)
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct UnpreparedError {
     /// Unknown ID.
     pub id: CBytesShort,

--- a/cassandra-protocol/src/frame/frame_response.rs
+++ b/cassandra-protocol/src/frame/frame_response.rs
@@ -11,11 +11,10 @@ use crate::frame::frame_result::{
     ResResultBody, RowsMetadata,
 };
 use crate::frame::frame_supported::*;
-use crate::frame::FromCursor;
-use crate::frame::Opcode;
+use crate::frame::{FromCursor, Opcode};
 use crate::types::rows::Row;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ResponseBody {
     Error(CdrsError),
     Startup,
@@ -33,6 +32,14 @@ pub enum ResponseBody {
     AuthChallenge(BodyResAuthChallenge),
     AuthResponse,
     AuthSuccess(BodyReqAuthSuccess),
+}
+
+// This implementation is incomplete so only enable in tests
+#[cfg(test)]
+use crate::frame::Serialize;
+#[cfg(test)]
+impl Serialize for ResponseBody {
+    fn serialize(&self, _cursor: &mut Cursor<&mut Vec<u8>>) {}
 }
 
 impl ResponseBody {

--- a/cassandra-protocol/src/frame/frame_result.rs
+++ b/cassandra-protocol/src/frame/frame_result.rs
@@ -79,7 +79,7 @@ impl FromCursor for ResultKind {
 
 /// `ResponseBody` is a generalized enum that represents all types of responses. Each of enum
 /// option wraps related body type.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ResResultBody {
     /// Void response body. It's an empty struct.
     Void(BodyResResultVoid),
@@ -157,7 +157,7 @@ impl FromCursor for ResResultBody {
 }
 
 /// Body of a response of type Void
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct BodyResResultVoid;
 
 impl FromBytes for BodyResResultVoid {
@@ -175,7 +175,7 @@ impl FromCursor for BodyResResultVoid {
 }
 
 /// It represents set keyspace result body. Body contains keyspace name.
-#[derive(Debug, Constructor)]
+#[derive(Debug, Constructor, PartialEq)]
 pub struct BodyResResultSetKeyspace {
     /// It contains name of keyspace that was set.
     pub body: CString,
@@ -189,7 +189,7 @@ impl FromCursor for BodyResResultSetKeyspace {
 
 /// Structure that represents result of type
 /// [rows](https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L533).
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct BodyResResultRows {
     /// Rows metadata
     pub metadata: RowsMetadata,
@@ -231,7 +231,7 @@ impl FromCursor for BodyResResultRows {
 }
 
 /// Rows metadata.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RowsMetadata {
     /// Flags.
     pub flags: RowsMetadataFlags,
@@ -304,14 +304,14 @@ impl FromBytes for RowsMetadataFlags {
 }
 
 /// Table specification.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TableSpec {
     pub ks_name: CString,
     pub table_name: CString,
 }
 
 /// Single column specification.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ColSpec {
     /// The initial <ks_name> and <table_name> are strings and only present
     /// if the Global_tables_spec flag is NOT set
@@ -440,7 +440,7 @@ impl FromCursor for ColType {
 }
 
 /// Cassandra option that represent column type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ColTypeOption {
     /// Id refers to `ColType`.
     pub id: ColType,
@@ -479,7 +479,7 @@ impl FromCursor for ColTypeOption {
 }
 
 /// Enum that represents all possible types of `value` of `ColTypeOption`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ColTypeOptionValue {
     CString(CString),
     ColType(ColType),
@@ -491,7 +491,7 @@ pub enum ColTypeOptionValue {
 }
 
 /// User defined type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CUdt {
     /// Keyspace name.
     pub ks: CString,
@@ -527,7 +527,7 @@ impl FromCursor for CUdt {
 
 /// User defined type.
 /// [Read more...](https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L608)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CTuple {
     /// List of types.
     pub types: Vec<ColTypeOption>,
@@ -550,7 +550,7 @@ impl FromCursor for CTuple {
 }
 
 /// The structure represents a body of a response frame of type `prepared`
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct BodyResResultPrepared {
     /// id of prepared request
     pub id: CBytesShort,
@@ -582,7 +582,7 @@ bitflags! {
 }
 
 /// The structure that represents metadata of prepared response.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PreparedMetadata {
     pub flags: PreparedMetadataFlags,
     pub columns_count: i32,

--- a/cassandra-protocol/src/frame/frame_supported.rs
+++ b/cassandra-protocol/src/frame/frame_supported.rs
@@ -5,7 +5,7 @@ use crate::error;
 use crate::frame::FromCursor;
 use crate::types::{CString, CStringList, SHORT_LEN};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct BodyResSupported {
     pub data: HashMap<String, Vec<String>>,
 }

--- a/cassandra-protocol/src/types.rs
+++ b/cassandra-protocol/src/types.rs
@@ -205,7 +205,7 @@ pub fn to_float_big(f: f64) -> Vec<u8> {
     f.to_be_bytes().into()
 }
 
-#[derive(Debug, Clone, Constructor)]
+#[derive(Debug, Clone, Constructor, PartialEq)]
 pub struct CString {
     string: String,
 }
@@ -252,7 +252,7 @@ impl FromCursor for CString {
     }
 }
 
-#[derive(Debug, Clone, Constructor)]
+#[derive(Debug, Clone, Constructor, PartialEq)]
 pub struct CStringLong {
     string: String,
 }
@@ -293,7 +293,7 @@ impl FromCursor for CStringLong {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CStringList {
     pub list: Vec<CString>,
 }


### PR DESCRIPTION
Adds test infrastructure that will be used for testing the encode and decode implementations which will come in follow up PRs.
For now just tests ResponseBody::Ready as that case already works.