### PR TITLE
Move protocol version selection to runtime

### DIFF
--- a/cassandra-protocol/Cargo.toml
+++ b/cassandra-protocol/Cargo.toml
@@ -11,11 +11,6 @@ keywords = ["cassandra", "client", "cassandradb"]
 license = "MIT/Apache-2.0"
 
 [features]
-default = ["v4"]
-v3 = []
-v4 = []
-# enable v5 feature when it's actually implemented
-# v5 = []
 e2e-tests = []
 
 [dependencies]

--- a/cassandra-protocol/src/frame/frame_auth_response.rs
+++ b/cassandra-protocol/src/frame/frame_auth_response.rs
@@ -20,13 +20,14 @@ impl Serialize for BodyReqAuthResponse {
 
 impl Frame {
     /// Creates new frame of type `AuthResponse`.
-    pub fn new_req_auth_response(token_bytes: CBytes) -> Frame {
-        let version = Version::Request;
+    pub fn new_req_auth_response(token_bytes: CBytes, version: Version) -> Frame {
+        let direction = Direction::Request;
         let opcode = Opcode::AuthResponse;
         let body = BodyReqAuthResponse::new(token_bytes);
 
         Frame::new(
             version,
+            direction,
             Flags::empty(),
             opcode,
             body.serialize_to_vec(),
@@ -51,9 +52,9 @@ mod tests {
     #[test]
     fn frame_body_req_auth_response() {
         let bytes = vec![1, 2, 3];
-        let frame = Frame::new_req_auth_response(CBytes::new(bytes));
+        let frame = Frame::new_req_auth_response(CBytes::new(bytes), Version::V4);
 
-        assert_eq!(frame.version, Version::Request);
+        assert_eq!(frame.version, Version::V4);
         assert_eq!(frame.opcode, Opcode::AuthResponse);
         assert_eq!(frame.body, &[0, 0, 0, 3, 1, 2, 3]);
         assert_eq!(frame.tracing_id, None);

--- a/cassandra-protocol/src/frame/frame_batch.rs
+++ b/cassandra-protocol/src/frame/frame_batch.rs
@@ -137,12 +137,13 @@ impl Serialize for BatchQuery {
 
 impl Frame {
     /// **Note:** This function should be used internally for building query request frames.
-    pub fn new_req_batch(query: BodyReqBatch, flags: Flags) -> Frame {
-        let version = Version::Request;
+    pub fn new_req_batch(query: BodyReqBatch, flags: Flags, version: Version) -> Frame {
+        let direction = Direction::Request;
         let opcode = Opcode::Batch;
 
         Frame::new(
             version,
+            direction,
             flags,
             opcode,
             query.serialize_to_vec(),

--- a/cassandra-protocol/src/frame/frame_execute.rs
+++ b/cassandra-protocol/src/frame/frame_execute.rs
@@ -24,14 +24,16 @@ impl Frame {
         id: &CBytesShort,
         query_parameters: &QueryParams,
         flags: Flags,
+        version: Version,
     ) -> Frame {
-        let version = Version::Request;
+        let direction = Direction::Request;
         let opcode = Opcode::Execute;
 
         let body = BodyReqExecute::new(id, query_parameters);
 
         Frame::new(
             version,
+            direction,
             flags,
             opcode,
             body.serialize_to_vec(),

--- a/cassandra-protocol/src/frame/frame_options.rs
+++ b/cassandra-protocol/src/frame/frame_options.rs
@@ -15,13 +15,14 @@ impl Serialize for BodyReqOptions {
 
 impl Frame {
     /// Creates new frame of type `options`.
-    pub fn new_req_options() -> Frame {
-        let version = Version::Request;
+    pub fn new_req_options(version: Version) -> Frame {
+        let direction = Direction::Request;
         let opcode = Opcode::Options;
         let body: BodyReqOptions = Default::default();
 
         Frame::new(
             version,
+            direction,
             Flags::empty(),
             opcode,
             body.serialize_to_vec(),
@@ -37,8 +38,8 @@ mod tests {
 
     #[test]
     fn test_frame_options() {
-        let frame = Frame::new_req_options();
-        assert_eq!(frame.version, Version::Request);
+        let frame = Frame::new_req_options(Version::V4);
+        assert_eq!(frame.version, Version::V4);
         assert_eq!(frame.opcode, Opcode::Options);
         assert!(frame.body.is_empty());
     }

--- a/cassandra-protocol/src/frame/frame_prepare.rs
+++ b/cassandra-protocol/src/frame/frame_prepare.rs
@@ -26,13 +26,14 @@ impl Serialize for BodyReqPrepare {
 }
 
 impl Frame {
-    pub fn new_req_prepare(query: String, flags: Flags) -> Frame {
-        let version = Version::Request;
+    pub fn new_req_prepare(query: String, flags: Flags, version: Version) -> Frame {
+        let direction = Direction::Request;
         let opcode = Opcode::Prepare;
         let body = BodyReqPrepare::new(query);
 
         Frame::new(
             version,
+            direction,
             flags,
             opcode,
             body.serialize_to_vec(),

--- a/cassandra-protocol/src/frame/frame_query.rs
+++ b/cassandra-protocol/src/frame/frame_query.rs
@@ -66,8 +66,9 @@ impl Frame {
         timestamp: Option<i64>,
         flags: Flags,
         is_idempotent: bool,
+        version: Version,
     ) -> Frame {
-        let version = Version::Request;
+        let direction = Direction::Request;
         let opcode = Opcode::Query;
         let body = BodyReqQuery::new(
             query,
@@ -83,6 +84,7 @@ impl Frame {
 
         Frame::new(
             version,
+            direction,
             flags,
             opcode,
             body.serialize_to_vec(),
@@ -92,7 +94,7 @@ impl Frame {
     }
 
     #[inline]
-    pub fn new_query(query: Query, flags: Flags) -> Frame {
+    pub fn new_query(query: Query, flags: Flags, version: Version) -> Frame {
         Frame::new_req_query(
             query.query,
             query.params.consistency,
@@ -104,6 +106,7 @@ impl Frame {
             query.params.timestamp,
             flags,
             query.params.is_idempotent,
+            version,
         )
     }
 }

--- a/cassandra-protocol/src/frame/frame_register.rs
+++ b/cassandra-protocol/src/frame/frame_register.rs
@@ -27,13 +27,14 @@ impl Serialize for BodyReqRegister {
 
 impl Frame {
     /// Creates new frame of type `REGISTER`.
-    pub fn new_req_register(events: Vec<SimpleServerEvent>) -> Frame {
-        let version = Version::Request;
+    pub fn new_req_register(events: Vec<SimpleServerEvent>, version: Version) -> Frame {
+        let direction = Direction::Request;
         let opcode = Opcode::Register;
         let register_body = BodyReqRegister { events };
 
         Frame::new(
             version,
+            direction,
             Flags::empty(),
             opcode,
             register_body.serialize_to_vec(),

--- a/cassandra-protocol/src/frame/frame_response.rs
+++ b/cassandra-protocol/src/frame/frame_response.rs
@@ -11,7 +11,7 @@ use crate::frame::frame_result::{
     ResResultBody, RowsMetadata,
 };
 use crate::frame::frame_supported::*;
-use crate::frame::{FromCursor, Opcode};
+use crate::frame::{FromCursor, Opcode, Version};
 use crate::types::rows::Row;
 
 #[derive(Debug, PartialEq)]
@@ -43,7 +43,11 @@ impl Serialize for ResponseBody {
 }
 
 impl ResponseBody {
-    pub fn from(bytes: &[u8], response_type: &Opcode) -> error::Result<ResponseBody> {
+    pub fn from(
+        bytes: &[u8],
+        response_type: &Opcode,
+        version: Version,
+    ) -> error::Result<ResponseBody> {
         let mut cursor: Cursor<&[u8]> = Cursor::new(bytes);
         Ok(match *response_type {
             // request frames
@@ -65,7 +69,9 @@ impl ResponseBody {
             Opcode::Supported => {
                 ResponseBody::Supported(BodyResSupported::from_cursor(&mut cursor)?)
             }
-            Opcode::Result => ResponseBody::Result(ResResultBody::from_cursor(&mut cursor)?),
+            Opcode::Result => {
+                ResponseBody::Result(ResResultBody::from_cursor(&mut cursor, version)?)
+            }
             Opcode::Event => ResponseBody::Event(BodyResEvent::from_cursor(&mut cursor)?),
             Opcode::AuthChallenge => {
                 ResponseBody::AuthChallenge(BodyResAuthChallenge::from_cursor(&mut cursor)?)

--- a/cassandra-protocol/src/frame/frame_startup.rs
+++ b/cassandra-protocol/src/frame/frame_startup.rs
@@ -45,13 +45,14 @@ impl<'a> Serialize for BodyReqStartup<'a> {
 
 impl Frame {
     /// Creates new frame of type `startup`.
-    pub fn new_req_startup(compression: Option<&str>) -> Frame {
-        let version = Version::Request;
+    pub fn new_req_startup(compression: Option<&str>, version: Version) -> Frame {
+        let direction = Direction::Request;
         let opcode = Opcode::Startup;
         let body = BodyReqStartup::new(compression);
 
         Frame::new(
             version,
+            direction,
             Flags::empty(),
             opcode,
             body.serialize_to_vec(),
@@ -85,8 +86,8 @@ mod test {
     #[test]
     fn new_req_startup() {
         let compression = Some("test_compression");
-        let frame = Frame::new_req_startup(compression);
-        assert_eq!(frame.version, Version::Request);
+        let frame = Frame::new_req_startup(compression, Version::V4);
+        assert_eq!(frame.version, Version::V4);
         assert_eq!(frame.flags, Flags::empty());
         assert_eq!(frame.opcode, Opcode::Startup);
         assert_eq!(frame.tracing_id, None);

--- a/cdrs-tokio/Cargo.toml
+++ b/cdrs-tokio/Cargo.toml
@@ -12,12 +12,7 @@ keywords = ["cassandra", "driver", "client", "cassandradb", "async"]
 license = "MIT/Apache-2.0"
 
 [features]
-default = ["v4"]
 rust-tls = ["rustls", "tokio-rustls", "webpki"]
-v3 = ["cassandra-protocol/v3"]
-v4 = ["cassandra-protocol/v4"]
-# enable v5 feature when it's actually implemented
-# v5 = ["cassandra-protocol/v5"]
 e2e-tests = []
 
 [dependencies]

--- a/cdrs-tokio/src/cluster.rs
+++ b/cdrs-tokio/src/cluster.rs
@@ -17,6 +17,7 @@ pub use self::topology::cluster_metadata::ClusterMetadata;
 use crate::future::BoxFuture;
 use crate::transport::CdrsTransport;
 use cassandra_protocol::error;
+use cassandra_protocol::frame::Version;
 
 mod cluster_metadata_manager;
 #[cfg(feature = "rust-tls")]
@@ -47,4 +48,7 @@ pub trait GenericClusterConfig<T: CdrsTransport, CM: ConnectionManager<T>>: Send
     /// Returns desired event channel capacity. Take a look at
     /// [`Session`](self::session::Session) builders for more info.
     fn event_channel_capacity(&self) -> usize;
+
+    /// Cassandra protocol version to use
+    fn version(&self) -> Version;
 }

--- a/cdrs-tokio/src/cluster/config_rustls.rs
+++ b/cdrs-tokio/src/cluster/config_rustls.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::cluster::NodeAddress;
 use cassandra_protocol::authenticators::{NoneAuthenticatorProvider, SaslAuthenticatorProvider};
 use cassandra_protocol::error::Result;
+use cassandra_protocol::frame::Version;
 
 /// Single node TLS connection config.
 #[derive(Clone)]
@@ -12,6 +13,7 @@ pub struct NodeRustlsConfig {
     pub dns_name: webpki::DNSName,
     pub authenticator_provider: Arc<dyn SaslAuthenticatorProvider + Send + Sync>,
     pub config: Arc<rustls::ClientConfig>,
+    pub version: Version,
 }
 
 /// Builder structure that helps to configure TLS connection for node.
@@ -20,6 +22,7 @@ pub struct NodeRustlsConfigBuilder {
     dns_name: webpki::DNSName,
     authenticator_provider: Arc<dyn SaslAuthenticatorProvider + Send + Sync>,
     config: Arc<rustls::ClientConfig>,
+    version: Version,
 }
 
 impl NodeRustlsConfigBuilder {
@@ -29,6 +32,7 @@ impl NodeRustlsConfigBuilder {
             dns_name,
             authenticator_provider: Arc::new(NoneAuthenticatorProvider),
             config,
+            version: Version::V4,
         }
     }
 
@@ -63,6 +67,12 @@ impl NodeRustlsConfigBuilder {
         self
     }
 
+    /// Set cassandra protocol version
+    pub fn with_version(mut self, version: Version) -> Self {
+        self.version = version;
+        self
+    }
+
     /// Finalizes building process
     pub async fn build(self) -> Result<NodeRustlsConfig> {
         // replace with map() when async lambdas become available
@@ -76,6 +86,7 @@ impl NodeRustlsConfigBuilder {
             dns_name: self.dns_name,
             authenticator_provider: self.authenticator_provider,
             config: self.config,
+            version: self.version,
         })
     }
 }

--- a/cdrs-tokio/src/cluster/config_tcp.rs
+++ b/cdrs-tokio/src/cluster/config_tcp.rs
@@ -4,18 +4,21 @@ use std::sync::Arc;
 use crate::cluster::NodeAddress;
 use cassandra_protocol::authenticators::{NoneAuthenticatorProvider, SaslAuthenticatorProvider};
 use cassandra_protocol::error::Result;
+use cassandra_protocol::frame::Version;
 
 /// Single node TCP connection config.
 #[derive(Clone)]
 pub struct NodeTcpConfig {
     pub contact_points: Vec<SocketAddr>,
     pub authenticator_provider: Arc<dyn SaslAuthenticatorProvider + Send + Sync>,
+    pub version: Version,
 }
 
 /// Builder structure that helps to configure TCP connection for node.
 pub struct NodeTcpConfigBuilder {
     addrs: Vec<NodeAddress>,
     authenticator_provider: Arc<dyn SaslAuthenticatorProvider + Send + Sync>,
+    version: Version,
 }
 
 impl Default for NodeTcpConfigBuilder {
@@ -23,6 +26,7 @@ impl Default for NodeTcpConfigBuilder {
         NodeTcpConfigBuilder {
             addrs: vec![],
             authenticator_provider: Arc::new(NoneAuthenticatorProvider),
+            version: Version::V4,
         }
     }
 }
@@ -63,6 +67,12 @@ impl NodeTcpConfigBuilder {
         self
     }
 
+    /// Set cassandra protocol version
+    pub fn with_version(mut self, version: Version) -> Self {
+        self.version = version;
+        self
+    }
+
     /// Finalizes building process
     pub async fn build(self) -> Result<NodeTcpConfig> {
         // replace with map() when async lambdas become available
@@ -74,6 +84,7 @@ impl NodeTcpConfigBuilder {
         Ok(NodeTcpConfig {
             contact_points,
             authenticator_provider: self.authenticator_provider,
+            version: self.version,
         })
     }
 }

--- a/cdrs-tokio/src/cluster/rustls_connection_manager.rs
+++ b/cdrs-tokio/src/cluster/rustls_connection_manager.rs
@@ -13,7 +13,7 @@ use crate::transport::TransportRustls;
 use cassandra_protocol::authenticators::SaslAuthenticatorProvider;
 use cassandra_protocol::compression::Compression;
 use cassandra_protocol::error::{Error, Result};
-use cassandra_protocol::frame::Frame;
+use cassandra_protocol::frame::{Frame, Version};
 
 pub struct RustlsConnectionManager {
     dns_name: webpki::DNSName,
@@ -24,6 +24,7 @@ pub struct RustlsConnectionManager {
     compression: Compression,
     buffer_size: usize,
     tcp_nodelay: bool,
+    version: Version,
 }
 
 impl ConnectionManager<TransportRustls> for RustlsConnectionManager {
@@ -64,6 +65,7 @@ impl RustlsConnectionManager {
         compression: Compression,
         buffer_size: usize,
         tcp_nodelay: bool,
+        version: Version,
     ) -> Self {
         RustlsConnectionManager {
             dns_name,
@@ -74,6 +76,7 @@ impl RustlsConnectionManager {
             compression,
             buffer_size,
             tcp_nodelay,
+            version,
         }
     }
 
@@ -101,6 +104,7 @@ impl RustlsConnectionManager {
             self.authenticator_provider.deref(),
             self.keyspace_holder.deref(),
             self.compression,
+            self.version,
         )
         .await?;
 

--- a/cdrs-tokio/src/cluster/tcp_connection_manager.rs
+++ b/cdrs-tokio/src/cluster/tcp_connection_manager.rs
@@ -14,7 +14,7 @@ use crate::transport::TransportTcp;
 use cassandra_protocol::authenticators::SaslAuthenticatorProvider;
 use cassandra_protocol::compression::Compression;
 use cassandra_protocol::error::{Error, Result};
-use cassandra_protocol::frame::Frame;
+use cassandra_protocol::frame::{Frame, Version};
 
 #[derive(Constructor)]
 pub struct TcpConnectionManager {
@@ -24,6 +24,7 @@ pub struct TcpConnectionManager {
     compression: Compression,
     buffer_size: usize,
     tcp_nodelay: bool,
+    version: Version,
 }
 
 impl ConnectionManager<TransportTcp> for TcpConnectionManager {
@@ -76,6 +77,7 @@ impl TcpConnectionManager {
             self.authenticator_provider.deref(),
             self.keyspace_holder.deref(),
             self.compression,
+            self.version,
         )
         .await?;
 

--- a/cdrs-tokio/src/frame_parser.rs
+++ b/cdrs-tokio/src/frame_parser.rs
@@ -6,7 +6,7 @@ use cassandra_protocol::compression::Compression;
 use cassandra_protocol::error;
 use cassandra_protocol::frame::frame_response::ResponseBody;
 use cassandra_protocol::frame::{
-    Flags, Frame, FromCursor, Opcode, Version, LENGTH_LEN, STREAM_LEN,
+    Direction, Flags, Frame, FromCursor, Opcode, Version, LENGTH_LEN, STREAM_LEN,
 };
 use cassandra_protocol::types::data_serialization_types::decode_timeuuid;
 use cassandra_protocol::types::{try_i16_from_bytes, try_i32_from_bytes, CStringList, UUID_LEN};
@@ -29,6 +29,7 @@ async fn parse_raw_frame<T: AsyncReadExt + Unpin>(
     cursor.read_exact(&mut length_bytes).await?;
 
     let version = Version::try_from(version_bytes[0])?;
+    let direction = Direction::from(version_bytes[0]);
     let flags = Flags::from_bits_truncate(flag_bytes[0]);
     let stream = try_i16_from_bytes(&stream_bytes)?;
     let opcode = Opcode::try_from(opcode_bytes[0])?;
@@ -68,6 +69,7 @@ async fn parse_raw_frame<T: AsyncReadExt + Unpin>(
 
     let frame = Frame {
         version,
+        direction,
         flags,
         opcode,
         stream,

--- a/cdrs-tokio/tests/collection_types.rs
+++ b/cdrs-tokio/tests/collection_types.rs
@@ -80,7 +80,7 @@ async fn list() {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "v4", feature = "e2e-tests"))]
+#[cfg(all(feature = "e2e-tests"))]
 async fn list_v4() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_lists_v4 \
                (my_text_list frozen<list<text>> PRIMARY KEY, \
@@ -196,7 +196,7 @@ async fn set() {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "v4", feature = "e2e-tests"))]
+#[cfg(all(feature = "e2e-tests"))]
 async fn set_v4() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_sets_v4 \
                (my_text_set frozen<set<text>> PRIMARY KEY, \
@@ -325,7 +325,7 @@ async fn map_without_blob() {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "v4", feature = "e2e-tests"))]
+#[cfg(all(feature = "e2e-tests"))]
 async fn map_without_blob_v4() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_maps_without_blob_v4 \
                (my_text_map frozen<map<text, text>> PRIMARY KEY, \

--- a/cdrs-tokio/tests/native_types.rs
+++ b/cdrs-tokio/tests/native_types.rs
@@ -149,7 +149,7 @@ async fn integer() {
 
 // TODO counter, varint
 #[tokio::test]
-#[cfg(all(feature = "v4", feature = "e2e-tests"))]
+#[cfg(all(feature = "e2e-tests"))]
 async fn integer_v4() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_integer_v4 \
                (my_bigint bigint PRIMARY KEY, my_int int, my_smallint smallint, \


### PR DESCRIPTION
The developer may wish to provide a configurable cassandra protocol version, this is impossible if the protocol is set at compile time.

* When deserializing a body the version comes from the frame.
* When serializing a frame I've tried to have the version come from a config struct in cdrs-tokio where possible but I think the API could be improved in the future.