### PR TITLE
Rename into_cbytes tests

### DIFF
--- a/cassandra-protocol/src/consistency.rs
+++ b/cassandra-protocol/src/consistency.rs
@@ -188,7 +188,7 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn test_consistency_into_cbytes() {
+    fn test_consistency_serialize() {
         assert_eq!(Consistency::Any.serialize_to_vec(), &[0, 0]);
         assert_eq!(Consistency::One.serialize_to_vec(), &[0, 1]);
         assert_eq!(Consistency::Two.serialize_to_vec(), &[0, 2]);

--- a/cassandra-protocol/src/frame/frame_ready.rs
+++ b/cassandra-protocol/src/frame/frame_ready.rs
@@ -21,7 +21,7 @@ mod tests {
     }
 
     #[test]
-    fn body_res_ready_into_cbytes() {
+    fn body_res_ready_serialize() {
         let body = BodyResReady;
         assert!(body.serialize_to_vec().is_empty());
     }

--- a/cassandra-protocol/src/types.rs
+++ b/cassandra-protocol/src/types.rs
@@ -581,7 +581,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cstring_into_cbytes() {
+    fn test_cstring_serialize() {
         let value = "foo".to_string();
         let cstring = CString::new(value);
 
@@ -620,7 +620,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cstringlong_into_cbytes() {
+    fn test_cstringlong_serialize() {
         let value = "foo".to_string();
         let cstring = CStringLong::new(value);
 
@@ -670,7 +670,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cbytes_into_cbytes() {
+    fn test_cbytes_serialize() {
         let bytes_vec = vec![1, 2, 3];
         let cbytes = CBytes::new(bytes_vec);
         assert_eq!(cbytes.serialize_to_vec(), vec![0, 0, 0, 3, 1, 2, 3]);
@@ -698,7 +698,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cbytesshort_into_cbytes() {
+    fn test_cbytesshort_serialize() {
         let bytes_vec: Vec<u8> = vec![1, 2, 3];
         let cbytes = CBytesShort::new(bytes_vec);
         assert_eq!(cbytes.serialize_to_vec(), vec![0, 3, 1, 2, 3]);

--- a/cassandra-protocol/src/types/decimal.rs
+++ b/cassandra-protocol/src/types/decimal.rs
@@ -83,7 +83,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn into_cbytes_test() {
+    fn serialize_test() {
         assert_eq!(
             Decimal::new(129.into(), 0).serialize_to_vec(),
             vec![0, 0, 0, 0, 0x00, 0x81]

--- a/cassandra-protocol/src/types/value.rs
+++ b/cassandra-protocol/src/types/value.rs
@@ -328,7 +328,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_value_type_into_cbytes() {
+    fn test_value_type_serialize() {
         // normal value types
         let normal_type = ValueType::Normal(1);
         assert_eq!(normal_type.serialize_to_vec(), vec![0, 0, 0, 1]);
@@ -382,7 +382,7 @@ mod tests {
     }
 
     #[test]
-    fn test_value_into_cbytes() {
+    fn test_value_serialize() {
         let value = Value::new_normal(1_u8);
         assert_eq!(value.serialize_to_vec(), vec![0, 0, 0, 1, 1]);
     }


### PR DESCRIPTION
Seems like this was left over from when `Serialize` used to be called `IntoCBytes` 