### PR TITLE
query params decoding

### DIFF
--- a/cassandra-protocol/src/frame/frame_query.rs
+++ b/cassandra-protocol/src/frame/frame_query.rs
@@ -1,11 +1,12 @@
 use crate::consistency::Consistency;
+use crate::frame::traits::FromCursor;
 use crate::frame::*;
 use crate::query::{Query, QueryParams, QueryValues};
 use crate::types::*;
 use std::io::Cursor;
 
 /// Structure which represents body of Query request
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct BodyReqQuery {
     /// Query string.
     pub query: CStringLong,
@@ -42,6 +43,18 @@ impl BodyReqQuery {
                 routing_key: None,
             },
         }
+    }
+}
+
+impl FromCursor for BodyReqQuery {
+    fn from_cursor(cursor: &mut Cursor<&[u8]>) -> error::Result<BodyReqQuery> {
+        let query = CStringLong::from_cursor(cursor)?;
+        let query_params = QueryParams::from_cursor(cursor)?;
+
+        Ok(BodyReqQuery {
+            query,
+            query_params,
+        })
     }
 }
 

--- a/cassandra-protocol/src/frame/frame_request.rs
+++ b/cassandra-protocol/src/frame/frame_request.rs
@@ -1,0 +1,29 @@
+use std::io::Cursor;
+
+use crate::error;
+use crate::frame::frame_query::BodyReqQuery;
+use crate::frame::{FromCursor, Opcode};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum RequestBody {
+    Query(BodyReqQuery),
+}
+
+use crate::frame::Serialize;
+impl Serialize for RequestBody {
+    fn serialize(&self, cursor: &mut Cursor<&mut Vec<u8>>) {
+        match self {
+            RequestBody::Query(query) => query.serialize(cursor),
+        }
+    }
+}
+
+impl RequestBody {
+    pub fn try_from(bytes: &[u8], response_type: Opcode) -> error::Result<RequestBody> {
+        let mut cursor: Cursor<&[u8]> = Cursor::new(bytes);
+        match response_type {
+            Opcode::Query => Ok(RequestBody::Query(BodyReqQuery::from_cursor(&mut cursor)?)),
+            _ => Err(format!("opcode {} is not a request", response_type).into()),
+        }
+    }
+}

--- a/cassandra-protocol/src/frame/frame_response.rs
+++ b/cassandra-protocol/src/frame/frame_response.rs
@@ -31,7 +31,12 @@ pub enum ResponseBody {
 use crate::frame::Serialize;
 #[cfg(test)]
 impl Serialize for ResponseBody {
-    fn serialize(&self, _cursor: &mut Cursor<&mut Vec<u8>>) {}
+    fn serialize(&self, _cursor: &mut Cursor<&mut Vec<u8>>) {
+        match self {
+            ResponseBody::Ready(_) => {}
+            _ => todo!(),
+        }
+    }
 }
 
 impl ResponseBody {
@@ -63,7 +68,7 @@ impl ResponseBody {
             Opcode::AuthSuccess => Ok(ResponseBody::AuthSuccess(BodyReqAuthSuccess::from_cursor(
                 &mut cursor,
             )?)),
-            _ => Err(format!("Unknown response opcode: {}", response_type).into()),
+            _ => Err(format!("opcode {} is not a response", response_type).into()),
         }
     }
 

--- a/cdrs-tokio/examples/crud_operations.rs
+++ b/cdrs-tokio/examples/crud_operations.rs
@@ -118,7 +118,7 @@ async fn select_struct(session: &mut CurrentSession) {
         .query(select_struct_cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");

--- a/cdrs-tokio/examples/generic_connection.rs
+++ b/cdrs-tokio/examples/generic_connection.rs
@@ -256,7 +256,7 @@ async fn select_struct(session: &mut CurrentSession) {
         .query(select_struct_cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");

--- a/cdrs-tokio/examples/insert_collection.rs
+++ b/cdrs-tokio/examples/insert_collection.rs
@@ -192,7 +192,7 @@ async fn select_struct(session: &mut CurrentSession) {
         .query(select_struct_cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");

--- a/cdrs-tokio/examples/multiple_thread.rs
+++ b/cdrs-tokio/examples/multiple_thread.rs
@@ -93,7 +93,7 @@ async fn select_struct(session: Arc<CurrentSession>) {
         .query(select_struct_cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");

--- a/cdrs-tokio/src/cluster/cluster_metadata_manager.rs
+++ b/cdrs-tokio/src/cluster/cluster_metadata_manager.rs
@@ -87,7 +87,7 @@ async fn send_query_with_params<T: CdrsTransport>(
     transport
         .write_frame(&frame)
         .await
-        .and_then(|frame| frame.body())
+        .and_then(|frame| frame.body_response())
         .map(|body| body.into_rows())
 }
 

--- a/cdrs-tokio/src/cluster/connection_manager.rs
+++ b/cdrs-tokio/src/cluster/connection_manager.rs
@@ -60,7 +60,7 @@ pub async fn startup<
     }
 
     if start_response.opcode == Opcode::Authenticate {
-        let body = start_response.body()?;
+        let body = start_response.body_response()?;
         let authenticator = body.authenticator()
             .ok_or_else(|| Error::General("Cassandra server did communicate that it needed authentication but the auth schema was missing in the body response".into()))?;
 
@@ -100,7 +100,7 @@ pub async fn startup<
             .await?;
 
         loop {
-            match frame.body()? {
+            match frame.body_response()? {
                 ResponseBody::AuthChallenge(challenge) => {
                     let response = authenticator.evaluate_challenge(challenge.data)?;
 

--- a/cdrs-tokio/src/cluster/control_connection.rs
+++ b/cdrs-tokio/src/cluster/control_connection.rs
@@ -148,7 +148,7 @@ impl<
     ) {
         tokio::spawn(async move {
             while let Some(frame) = event_frame_receiver.recv().await {
-                if let Ok(body) = frame.body() {
+                if let Ok(body) = frame.body_response() {
                     if let Some(event) = body.into_server_event() {
                         let _ = event_sender.send(event.event);
                     }

--- a/cdrs-tokio/src/cluster/pager.rs
+++ b/cdrs-tokio/src/cluster/pager.rs
@@ -140,7 +140,7 @@ impl<
             .session
             .query_with_params(query, params.finalize())
             .await
-            .and_then(|frame| frame.body())?;
+            .and_then(|frame| frame.body_response())?;
 
         let metadata_res: error::Result<RowsMetadata> = body
             .as_rows_metadata()
@@ -193,7 +193,7 @@ impl<
             .session
             .exec_with_params(self.query, params.finalize())
             .await
-            .and_then(|frame| frame.body())?;
+            .and_then(|frame| frame.body_response())?;
 
         let metadata_res: error::Result<RowsMetadata> = body
             .as_rows_metadata()

--- a/cdrs-tokio/src/cluster/session.rs
+++ b/cdrs-tokio/src/cluster/session.rs
@@ -290,7 +290,7 @@ impl<
 
         send_frame(self, query_frame, false, None, None, None, None)
             .await
-            .and_then(|response| response.body())
+            .and_then(|response| response.body_response())
             .and_then(|body| {
                 body.into_prepared()
                     .ok_or_else(|| "CDRS BUG: cannot convert frame into prepared".into())

--- a/cdrs-tokio/src/frame_parser.rs
+++ b/cdrs-tokio/src/frame_parser.rs
@@ -90,7 +90,7 @@ pub async fn parse_frame<T: AsyncReadExt + Unpin>(
 
 fn convert_frame_into_result(frame: Frame) -> error::Result<Frame> {
     match frame.opcode {
-        Opcode::Error => frame.body().and_then(|err| match err {
+        Opcode::Error => frame.body_response().and_then(|err| match err {
             ResponseBody::Error(err) => Err(error::Error::Server(err)),
             _ => unreachable!(),
         }),

--- a/cdrs-tokio/src/transport.rs
+++ b/cdrs-tokio/src/transport.rs
@@ -310,7 +310,7 @@ impl AsyncTransport {
                         if frame.opcode == Opcode::Result {
                             let result_kind = ResultKind::from_bytes(&frame.body[..INT_LEN])?;
                             if result_kind == ResultKind::SetKeyspace {
-                                let response_body = frame.body()?;
+                                let response_body = frame.body_response()?;
                                 let set_keyspace =
                                     response_body.into_set_keyspace().ok_or_else(|| {
                                         Error::General(

--- a/cdrs-tokio/tests/collection_types.rs
+++ b/cdrs-tokio/tests/collection_types.rs
@@ -50,7 +50,7 @@ async fn list() {
         .query(cql)
         .await
         .expect("query lists error")
-        .body()
+        .body_response()
         .expect("get body with lists error")
         .into_rows()
         .expect("converting body with lists into rows error");
@@ -108,7 +108,7 @@ async fn list_v4() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -166,7 +166,7 @@ async fn set() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -224,7 +224,7 @@ async fn set_v4() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -295,7 +295,7 @@ async fn map_without_blob() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -365,7 +365,7 @@ async fn map_without_blob_v4() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -435,7 +435,7 @@ async fn map() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");

--- a/cdrs-tokio/tests/derive_traits.rs
+++ b/cdrs-tokio/tests/derive_traits.rs
@@ -85,7 +85,7 @@ async fn simple_udt() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -152,7 +152,7 @@ async fn nested_udt() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -235,7 +235,7 @@ async fn alter_udt_add() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -338,7 +338,7 @@ async fn update_list_with_udt() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");

--- a/cdrs-tokio/tests/keyspace.rs
+++ b/cdrs-tokio/tests/keyspace.rs
@@ -54,7 +54,7 @@ async fn create_keyspace() {
         .query(select_query)
         .await
         .expect("select keyspace query")
-        .body()
+        .body_response()
         .expect("get select keyspace query body")
         .into_rows()
         .expect("convert keyspaces results into rows");
@@ -134,7 +134,7 @@ async fn alter_keyspace() {
         .query(select_query)
         .await
         .expect("select keyspace query")
-        .body()
+        .body_response()
         .expect("get select keyspace query body")
         .into_rows()
         .expect("convert keyspaces results into rows");
@@ -184,7 +184,7 @@ async fn use_keyspace() {
         .query(use_query)
         .await
         .expect("should use selected")
-        .body()
+        .body_response()
         .expect("should get body")
         .into_set_keyspace()
         .expect("set keyspace")

--- a/cdrs-tokio/tests/native_types.rs
+++ b/cdrs-tokio/tests/native_types.rs
@@ -53,7 +53,7 @@ async fn string() {
         .query(cql)
         .await
         .expect("select strings query error")
-        .body()
+        .body_response()
         .expect("get body error")
         .into_rows()
         .expect("converting into rows error");
@@ -92,7 +92,7 @@ async fn counter() {
         .query(cql)
         .await
         .expect("select counter query error")
-        .body()
+        .body_response()
         .expect("get counter body error")
         .into_rows()
         .expect("converting coutner body into rows error");
@@ -131,7 +131,7 @@ async fn integer() {
         .query(cql)
         .await
         .expect("select integers query error")
-        .body()
+        .body_response()
         .expect("get body with integers error")
         .into_rows()
         .expect("converting body with integers into rows error");
@@ -175,7 +175,7 @@ async fn integer_v4() {
         .query(cql)
         .await
         .expect("query integers error")
-        .body()
+        .body_response()
         .expect("get body with integers error")
         .into_rows()
         .expect("converting body with integers into rows error");
@@ -224,7 +224,7 @@ async fn float() {
         .query(cql)
         .await
         .expect("query floats error")
-        .body()
+        .body_response()
         .expect("get body with floats error")
         .into_rows()
         .expect("converting body with floats into rows error");
@@ -279,7 +279,7 @@ async fn blob() {
         .query(cql)
         .await
         .expect("query blobs error")
-        .body()
+        .body_response()
         .expect("get body with blobs error")
         .into_rows()
         .expect("converting body with blobs into rows error");
@@ -319,7 +319,7 @@ async fn uuid() {
         .query(cql)
         .await
         .expect("query UUID error")
-        .body()
+        .body_response()
         .expect("get body with UUID error")
         .into_rows()
         .expect("conversion body with UUID into rows error");
@@ -353,7 +353,7 @@ async fn time() {
         .query(cql)
         .await
         .expect("query with time error")
-        .body()
+        .body_response()
         .expect("get body with time error")
         .into_rows()
         .expect("converting body with time into rows error");
@@ -392,7 +392,7 @@ async fn inet() {
         .query(query)
         .await
         .expect("query inet error")
-        .body()
+        .body_response()
         .expect("get body with inet error")
         .into_rows()
         .expect("converting body with inet into rows error");

--- a/cdrs-tokio/tests/query_values.rs
+++ b/cdrs-tokio/tests/query_values.rs
@@ -37,7 +37,7 @@ async fn query_values_in() {
         .query_with_values(cql, query_values!(criteria.clone()))
         .await
         .expect("select values query error")
-        .body()
+        .body_response()
         .expect("get body error")
         .into_rows()
         .expect("converting into rows error");

--- a/cdrs-tokio/tests/topology_aware.rs
+++ b/cdrs-tokio/tests/topology_aware.rs
@@ -74,7 +74,7 @@ async fn query_topology_aware() {
         .query_with_values(cql, query_values!(criteria.clone()))
         .await
         .expect("select values query error")
-        .body()
+        .body_response()
         .expect("get body error")
         .into_rows()
         .expect("converting into rows error");

--- a/cdrs-tokio/tests/tuple_types.rs
+++ b/cdrs-tokio/tests/tuple_types.rs
@@ -80,7 +80,7 @@ async fn simple_tuple() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -197,7 +197,7 @@ async fn nested_tuples() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");

--- a/cdrs-tokio/tests/user_defined_types.rs
+++ b/cdrs-tokio/tests/user_defined_types.rs
@@ -76,7 +76,7 @@ async fn simple_udt() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -164,7 +164,7 @@ async fn nested_udt() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");
@@ -252,7 +252,7 @@ async fn alter_udt_add() {
         .query(cql)
         .await
         .expect("query")
-        .body()
+        .body_response()
         .expect("get body")
         .into_rows()
         .expect("into rows");


### PR DESCRIPTION
* I had to add `test_encode_decode_roundtrip_nondeterministic` because of the hashmap in NamedValues