### PR TITLE
Remove CString

### DIFF
--- a/cassandra-protocol/src/error.rs
+++ b/cassandra-protocol/src/error.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Display};
 use std::io;
 use std::result;
+use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 use thiserror::Error as ThisError;
 use uuid::Error as UuidError;
@@ -27,8 +28,11 @@ pub enum Error {
     #[error("General error: {0}")]
     General(String),
     /// Internal error that may be raised during `String::from_utf8`
-    #[error("Utf8 error: {0}")]
+    #[error("FromUtf8 error: {0}")]
     FromUtf8(#[from] FromUtf8Error),
+    /// Internal error that may be raised during `str::from_utf8`
+    #[error("Utf8 error: {0}")]
+    Utf8(#[from] Utf8Error),
     /// Internal Compression/Decompression error
     #[error("Compressor error: {0}")]
     Compression(#[from] CompressionError),

--- a/cassandra-protocol/src/frame/frame_authenticate.rs
+++ b/cassandra-protocol/src/frame/frame_authenticate.rs
@@ -2,26 +2,26 @@ use std::io::Cursor;
 
 use crate::error;
 use crate::frame::FromCursor;
-use crate::types::CString;
+use crate::types::{from_cursor_str, serialize_str};
 
 use super::Serialize;
 
 /// A server authentication challenge.
 #[derive(Debug, PartialEq, Ord, PartialOrd, Eq, Hash, Clone)]
 pub struct BodyResAuthenticate {
-    pub data: CString,
+    pub data: String,
 }
 
 impl Serialize for BodyResAuthenticate {
     fn serialize(&self, cursor: &mut Cursor<&mut Vec<u8>>) {
-        self.data.serialize(cursor);
+        serialize_str(cursor, &self.data);
     }
 }
 
 impl FromCursor for BodyResAuthenticate {
     fn from_cursor(mut cursor: &mut Cursor<&[u8]>) -> error::Result<BodyResAuthenticate> {
         Ok(BodyResAuthenticate {
-            data: CString::from_cursor(&mut cursor)?,
+            data: from_cursor_str(&mut cursor)?.to_string(),
         })
     }
 }
@@ -37,7 +37,7 @@ mod tests {
         // string "abcde"
         let bytes = [0, 5, 97, 98, 99, 100, 101];
         let expected = BodyResAuthenticate {
-            data: CString::new("abcde".into()),
+            data: "abcde".into(),
         };
 
         {

--- a/cassandra-protocol/src/frame/frame_register.rs
+++ b/cassandra-protocol/src/frame/frame_register.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 
 use crate::frame::events::SimpleServerEvent;
 use crate::frame::*;
-use crate::types::{CString, CStringList};
+use crate::types::CStringList;
 
 /// The structure which represents a body of a frame of type `options`.
 pub struct BodyReqRegister {
@@ -12,11 +12,7 @@ pub struct BodyReqRegister {
 impl Serialize for BodyReqRegister {
     fn serialize(&self, cursor: &mut Cursor<&mut Vec<u8>>) {
         let events_string_list = CStringList {
-            list: self
-                .events
-                .iter()
-                .map(|event| CString::new(event.as_string()))
-                .collect(),
+            list: self.events.iter().map(|event| event.as_string()).collect(),
         };
 
         events_string_list.serialize(cursor)

--- a/cassandra-protocol/src/frame/frame_startup.rs
+++ b/cassandra-protocol/src/frame/frame_startup.rs
@@ -30,13 +30,8 @@ impl<'a> Serialize for BodyReqStartup<'a> {
         num.serialize(cursor);
 
         for (key, val) in &self.map {
-            let key_len = key.len() as CIntShort;
-            key_len.serialize(cursor);
-            key.serialize(cursor);
-
-            let val_len = val.len() as CIntShort;
-            val_len.serialize(cursor);
-            val.serialize(cursor);
+            serialize_str(cursor, key);
+            serialize_str(cursor, val);
         }
     }
 }

--- a/cassandra-protocol/src/frame/frame_supported.rs
+++ b/cassandra-protocol/src/frame/frame_supported.rs
@@ -3,7 +3,7 @@ use std::io::{Cursor, Read};
 
 use crate::error;
 use crate::frame::FromCursor;
-use crate::types::{serialize_str, CString, CStringList, SHORT_LEN};
+use crate::types::{from_cursor_str, serialize_str, CStringList, SHORT_LEN};
 
 use super::Serialize;
 
@@ -31,7 +31,7 @@ impl FromCursor for BodyResSupported {
         let l = i16::from_be_bytes(buff) as usize;
         let mut data: HashMap<String, Vec<String>> = HashMap::with_capacity(l);
         for _ in 0..l {
-            let name = CString::from_cursor(cursor)?.into_plain();
+            let name = from_cursor_str(cursor)?.to_string();
             let val = CStringList::from_cursor(cursor)?.into_plain();
             data.insert(name, val);
         }

--- a/cassandra-protocol/src/frame/traits.rs
+++ b/cassandra-protocol/src/frame/traits.rs
@@ -69,20 +69,6 @@ impl Serialize for Vec<u8> {
     }
 }
 
-impl Serialize for String {
-    #[inline]
-    fn serialize(&self, cursor: &mut Cursor<&mut Vec<u8>>) {
-        let _ = cursor.write(self.as_bytes());
-    }
-}
-
-impl Serialize for &str {
-    #[inline]
-    fn serialize(&self, cursor: &mut Cursor<&mut Vec<u8>>) {
-        let _ = cursor.write(self.as_bytes());
-    }
-}
-
 impl Serialize for BigInt {
     #[inline]
     fn serialize(&self, cursor: &mut Cursor<&mut Vec<u8>>) {

--- a/cassandra-protocol/src/query/query_params.rs
+++ b/cassandra-protocol/src/query/query_params.rs
@@ -8,9 +8,8 @@ use crate::frame::traits::FromCursor;
 use crate::frame::Serialize;
 use crate::query::query_flags::QueryFlags;
 use crate::query::query_values::QueryValues;
-use crate::types::value::Value;
-use crate::types::CIntShort;
-use crate::types::{CBytes, CString};
+use crate::types::CBytes;
+use crate::types::{from_cursor_str, value::Value, CIntShort};
 use crate::Error;
 
 /// Parameters of Query for query operation.
@@ -129,7 +128,7 @@ impl FromCursor for QueryParams {
                 let mut map = HashMap::with_capacity(number_of_values as usize);
                 for _ in 0..number_of_values {
                     map.insert(
-                        CString::from_cursor(cursor)?.as_plain(),
+                        from_cursor_str(cursor)?.to_string(),
                         Value::from_cursor(cursor)?,
                     );
                 }

--- a/cassandra-protocol/src/query/query_values.rs
+++ b/cassandra-protocol/src/query/query_values.rs
@@ -3,8 +3,8 @@ use std::hash::Hash;
 use std::io::Cursor;
 
 use crate::frame::Serialize;
+use crate::types::serialize_str;
 use crate::types::value::Value;
-use crate::types::CIntShort;
 
 /// Enum that represents two types of query values:
 /// * values without name
@@ -76,9 +76,7 @@ impl Serialize for QueryValues {
             }
             QueryValues::NamedValues(v) => {
                 for (key, value) in v {
-                    let len = key.len() as CIntShort;
-                    len.serialize(cursor);
-                    key.serialize(cursor);
+                    serialize_str(cursor, key);
                     value.serialize(cursor);
                 }
             }

--- a/cassandra-protocol/src/types/data_serialization_types.rs
+++ b/cassandra-protocol/src/types/data_serialization_types.rs
@@ -245,7 +245,7 @@ mod tests {
     use super::super::super::error::*;
     use super::super::super::frame::frame_result::*;
     use super::*;
-    use crate::types::{to_float, to_float_big, CString};
+    use crate::types::{to_float, to_float_big};
     use float_eq::*;
     use std::net::IpAddr;
 
@@ -458,9 +458,9 @@ mod tests {
     fn as_rust_v4_blob_test() {
         let d_type = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.BytesType".into(),
-            ))),
+            )),
         };
         let data = CBytes::new(vec![1, 2, 3]);
         assert_eq!(
@@ -531,9 +531,9 @@ mod tests {
     fn as_rust_v4_bool_test() {
         let type_boolean = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.BooleanType".into(),
-            ))),
+            )),
         };
         let data_true = CBytes::new(vec![1]);
         let data_false = CBytes::new(vec![0]);
@@ -577,21 +577,21 @@ mod tests {
     fn as_rust_v4_i64_test() {
         let type_bigint = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.LongType".into(),
-            ))),
+            )),
         };
         let type_timestamp = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.TimestampType".into(),
-            ))),
+            )),
         };
         let type_time = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.TimeType".into(),
-            ))),
+            )),
         };
         let data = CBytes::new(vec![0, 0, 0, 0, 0, 0, 0, 100]);
         assert_eq!(as_rust_type!(type_bigint, data, i64).unwrap().unwrap(), 100);
@@ -626,15 +626,15 @@ mod tests {
     fn as_rust_v4_i32_test() {
         let type_int = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.Int32Type".into(),
-            ))),
+            )),
         };
         let type_date = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.SimpleDateType".into(),
-            ))),
+            )),
         };
         let data = CBytes::new(vec![0, 0, 0, 100]);
         assert_eq!(as_rust_type!(type_int, data, i32).unwrap().unwrap(), 100);
@@ -663,9 +663,9 @@ mod tests {
     fn as_rust_v4_i16_test() {
         let type_smallint = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.ShortType".into(),
-            ))),
+            )),
         };
         let data = CBytes::new(vec![0, 100]);
         assert_eq!(
@@ -693,9 +693,9 @@ mod tests {
     fn as_rust_v4_i8_test() {
         let type_tinyint = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.ByteType".into(),
-            ))),
+            )),
         };
         let data = CBytes::new(vec![100]);
         assert_eq!(as_rust_type!(type_tinyint, data, i8).unwrap().unwrap(), 100);
@@ -724,9 +724,9 @@ mod tests {
     fn as_rust_v4_f64_test() {
         let type_double = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.DoubleType".into(),
-            ))),
+            )),
         };
         let data = CBytes::new(to_float_big(0.1_f64));
         assert_float_eq!(
@@ -762,9 +762,9 @@ mod tests {
         // let type_decimal = ColTypeOption { id: ColType::Decimal };
         let type_float = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.FloatType".into(),
-            ))),
+            )),
         };
         let data = CBytes::new(to_float(0.1_f32));
         // assert_eq!(as_rust_type!(type_decimal, data, f32).unwrap(), 100.0);
@@ -798,9 +798,9 @@ mod tests {
     fn as_rust_v4_inet_test() {
         let type_inet = ColTypeOption {
             id: ColType::Custom,
-            value: Some(ColTypeOptionValue::CString(CString::new(
+            value: Some(ColTypeOptionValue::CString(
                 "org.apache.cassandra.db.marshal.InetAddressType".into(),
-            ))),
+            )),
         };
         let data = CBytes::new(vec![0, 0, 0, 0]);
 

--- a/cassandra-protocol/src/types/udt.rs
+++ b/cassandra-protocol/src/types/udt.rs
@@ -29,10 +29,8 @@ impl Udt {
         let acc: HashMap<String, (ColTypeOption, CBytes)> =
             HashMap::with_capacity(metadata.descriptions.len());
         let d = meta_iter.zip(data.iter()).fold(acc, |mut a, v| {
-            let (m, val_b) = v;
-            let &(ref name_b, ref val_type) = m;
-            let name = name_b.as_plain();
-            a.insert(name, (val_type.clone(), val_b.clone()));
+            let ((name, val_type), val_b) = v;
+            a.insert(name.clone(), (val_type.clone(), val_b.clone()));
             a
         });
 

--- a/cdrs-tokio/src/cluster/session.rs
+++ b/cdrs-tokio/src/cluster/session.rs
@@ -322,7 +322,7 @@ impl<
                 keyspace: result
                     .metadata
                     .global_table_spec
-                    .map(|TableSpec { ks_name, .. }| ks_name.as_plain()),
+                    .map(|TableSpec { ks_name, .. }| ks_name),
                 pk_indexes: result.metadata.pk_indexes,
             })
     }

--- a/cdrs-tokio/src/transport.rs
+++ b/cdrs-tokio/src/transport.rs
@@ -318,8 +318,7 @@ impl AsyncTransport {
                                         )
                                     })?;
 
-                                keyspace_holder
-                                    .update_current_keyspace(set_keyspace.body.into_plain());
+                                keyspace_holder.update_current_keyspace(set_keyspace.body);
                             }
                         }
 


### PR DESCRIPTION
This PR improves:
* cassandra-protocol UX - users can directly use String types without worrying about cassandra implementation details
* speed - removes many allocations

Future work:
We will also want to remove CStringLong and CStringList but this PR is already large enough.