### PR TITLE
Ignore body in Frame debug formatting

### DIFF
--- a/cassandra-protocol/Cargo.toml
+++ b/cassandra-protocol/Cargo.toml
@@ -25,3 +25,4 @@ snap = "1"
 thiserror = "1"
 time = { version = "0.3", features = ["std", "macros"] }
 uuid = "0.8"
+derivative = "2.2.0"

--- a/cassandra-protocol/src/frame.rs
+++ b/cassandra-protocol/src/frame.rs
@@ -1,5 +1,6 @@
 //! `frame` module contains general Frame functionality.
 use bitflags::bitflags;
+use derivative::Derivative;
 use derive_more::Display;
 use std::convert::TryFrom;
 use std::io::Cursor;
@@ -70,13 +71,15 @@ fn next_stream_id() -> StreamId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
+#[derive(Derivative, Clone, PartialEq, Ord, PartialOrd, Eq, Hash)]
+#[derivative(Debug)]
 pub struct Frame {
     pub version: Version,
     pub direction: Direction,
     pub flags: Flags,
     pub opcode: Opcode,
     pub stream: StreamId,
+    #[derivative(Debug = "ignore")]
     pub body: Vec<u8>,
     pub tracing_id: Option<Uuid>,
     pub warnings: Vec<String>,


### PR DESCRIPTION
Printing `Frame` with `{:?}` dumps the entire body to the logs and makes them noisy. 