### PR TITLE
Make send_frame public

### DIFF
--- a/cdrs-tokio/src/cluster.rs
+++ b/cdrs-tokio/src/cluster.rs
@@ -35,7 +35,7 @@ mod node_info;
 mod pager;
 #[cfg(feature = "rust-tls")]
 mod rustls_connection_manager;
-mod send_frame;
+pub mod send_frame;
 pub mod session;
 mod session_context;
 mod tcp_connection_manager;

--- a/cdrs-tokio/src/cluster/send_frame.rs
+++ b/cdrs-tokio/src/cluster/send_frame.rs
@@ -8,7 +8,7 @@ use cassandra_protocol::error;
 use cassandra_protocol::frame::Frame;
 use cassandra_protocol::query::query_params::Murmur3Token;
 
-pub(crate) async fn send_frame<
+pub async fn send_frame<
     T: CdrsTransport + 'static,
     CM: ConnectionManager<T> + Send + Sync + 'static,
     LB: LoadBalancingStrategy<T, CM> + Send + Sync + 'static,


### PR DESCRIPTION
Allows lower-level use of `Session` e.g.

```Rust
let response: Result<Frame, cassandra_protocol::error::Error> = {
    let mut query_params = QueryParamsBuilder::new().finalize();

    let is_idempotent = query_params.is_idempotent;
    let keyspace = query_params.keyspace.as_deref();
    let token = query_params.token.take();

    cdrs_tokio::cluster::send_frame::send_frame(
        &self.session,
        frame,
        is_idempotent,
        keyspace,
        token,
        None,
        None,
      )
      .await
};
```