### PR TITLE
Revert wrapping warnings in an Option

### DIFF
--- a/cassandra-protocol/src/frame.rs
+++ b/cassandra-protocol/src/frame.rs
@@ -68,7 +68,7 @@ pub struct Frame {
     #[derivative(Debug = "ignore")]
     pub body: Vec<u8>,
     pub tracing_id: Option<Uuid>,
-    pub warnings: Option<Vec<String>>,
+    pub warnings: Vec<String>,
 }
 
 impl Frame {
@@ -88,7 +88,7 @@ impl Frame {
     }
 
     #[inline]
-    pub fn warnings(&self) -> &Option<Vec<String>> {
+    pub fn warnings(&self) -> &[String] {
         &self.warnings
     }
 
@@ -144,12 +144,9 @@ impl Frame {
         };
 
         let warnings = if flags.contains(Flags::WARNING) {
-            Some(
-                from_cursor_string_list(&mut body_cursor)
-                    .map_err(ParseFrameError::InvalidWarnings)?,
-            )
+            from_cursor_string_list(&mut body_cursor).map_err(ParseFrameError::InvalidWarnings)?
         } else {
-            None
+            vec![]
         };
 
         let mut body = Vec::with_capacity(body_len - body_cursor.position() as usize);
@@ -521,7 +518,7 @@ mod tests {
             opcode: Opcode::Ready,
             body: vec![],
             tracing_id: None,
-            warnings: None,
+            warnings: vec![],
         };
         let body = ResponseBody::Ready;
         test_encode_decode_roundtrip_response(&raw_frame, frame, body);
@@ -539,7 +536,7 @@ mod tests {
             opcode: Opcode::Query,
             body: vec![0, 0, 0, 4, 98, 108, 97, 104, 0, 0, 64],
             tracing_id: None,
-            warnings: None,
+            warnings: vec![],
         };
         let body = RequestBody::Query(BodyReqQuery {
             query: "blah".into(),
@@ -576,7 +573,7 @@ mod tests {
                 0, 3, 1, 2, 3, 255, 255, 255, 255,
             ],
             tracing_id: None,
-            warnings: None,
+            warnings: vec![],
         };
         let body = RequestBody::Query(BodyReqQuery {
             query: "some query".into(),
@@ -609,7 +606,7 @@ mod tests {
             opcode: Opcode::Query,
             body: vec![],
             tracing_id: None,
-            warnings: None,
+            warnings: vec![],
         };
         let body = RequestBody::Query(BodyReqQuery {
             query: "another query".into(),

--- a/cassandra-protocol/src/frame/frame_auth_response.rs
+++ b/cassandra-protocol/src/frame/frame_auth_response.rs
@@ -32,7 +32,7 @@ impl Frame {
             opcode,
             body.serialize_to_vec(),
             None,
-            None,
+            vec![],
         )
     }
 }
@@ -58,6 +58,6 @@ mod tests {
         assert_eq!(frame.opcode, Opcode::AuthResponse);
         assert_eq!(frame.body, &[0, 0, 0, 3, 1, 2, 3]);
         assert_eq!(frame.tracing_id, None);
-        assert!(frame.warnings.is_none());
+        assert!(frame.warnings.is_empty());
     }
 }

--- a/cassandra-protocol/src/frame/frame_batch.rs
+++ b/cassandra-protocol/src/frame/frame_batch.rs
@@ -144,7 +144,7 @@ impl Frame {
             opcode,
             query.serialize_to_vec(),
             None,
-            None,
+            vec![],
         )
     }
 }

--- a/cassandra-protocol/src/frame/frame_execute.rs
+++ b/cassandra-protocol/src/frame/frame_execute.rs
@@ -47,7 +47,7 @@ impl Frame {
             opcode,
             body.serialize_to_vec(),
             None,
-            None,
+            vec![],
         )
     }
 }

--- a/cassandra-protocol/src/frame/frame_options.rs
+++ b/cassandra-protocol/src/frame/frame_options.rs
@@ -27,7 +27,7 @@ impl Frame {
             opcode,
             body.serialize_to_vec(),
             None,
-            None,
+            vec![],
         )
     }
 }

--- a/cassandra-protocol/src/frame/frame_prepare.rs
+++ b/cassandra-protocol/src/frame/frame_prepare.rs
@@ -45,7 +45,7 @@ impl Frame {
             opcode,
             body.serialize_to_vec(),
             None,
-            None,
+            vec![],
         )
     }
 }

--- a/cassandra-protocol/src/frame/frame_query.rs
+++ b/cassandra-protocol/src/frame/frame_query.rs
@@ -111,7 +111,7 @@ impl Frame {
             opcode,
             body.serialize_to_vec(),
             None,
-            None,
+            vec![],
         )
     }
 

--- a/cassandra-protocol/src/frame/frame_register.rs
+++ b/cassandra-protocol/src/frame/frame_register.rs
@@ -32,7 +32,7 @@ impl Frame {
             opcode,
             register_body.serialize_to_vec(),
             None,
-            None,
+            vec![],
         )
     }
 }

--- a/cassandra-protocol/src/frame/frame_startup.rs
+++ b/cassandra-protocol/src/frame/frame_startup.rs
@@ -52,7 +52,7 @@ impl Frame {
             opcode,
             body.serialize_to_vec(),
             None,
-            None,
+            vec![],
         )
     }
 }
@@ -86,6 +86,6 @@ mod test {
         assert_eq!(frame.flags, Flags::empty());
         assert_eq!(frame.opcode, Opcode::Startup);
         assert_eq!(frame.tracing_id, None);
-        assert!(frame.warnings.is_none());
+        assert!(frame.warnings.is_empty());
     }
 }

--- a/cdrs-tokio/src/frame_parser.rs
+++ b/cdrs-tokio/src/frame_parser.rs
@@ -62,9 +62,9 @@ async fn parse_raw_frame<T: AsyncReadExt + Unpin>(
     };
 
     let warnings = if flags.contains(Flags::WARNING) {
-        Some(from_cursor_string_list(&mut body_cursor)?)
+        from_cursor_string_list(&mut body_cursor)?
     } else {
-        None
+        vec![]
     };
 
     let mut body = Vec::with_capacity(body_len - body_cursor.position() as usize);


### PR DESCRIPTION
I happened to notice today that Vec does not allocate when constructed with capacity 0:
* https://doc.rust-lang.org/std/vec/struct.Vec.html#method.new
* https://doc.rust-lang.org/std/vec/struct.Vec.html#method.with_capacity

This means that `Vec::new()`, `vec![]` and `Vec::with_capacity(0)` will all cause no allocations.

Because of this wrapping the warnings in Option provides no benefit.