### PR TITLE
Typed collections

### DIFF
--- a/cassandra-protocol/src/macros.rs
+++ b/cassandra-protocol/src/macros.rs
@@ -119,6 +119,29 @@ macro_rules! map_as_cassandra_type {
     };
 }
 
+macro_rules! tuple_as_cassandra_type {
+    () => {
+        impl crate::types::AsCassandraType for Tuple {
+            fn as_cassandra_type(
+                &self,
+            ) -> Result<Option<crate::types::cassandra_type::CassandraType>> {
+                use crate::types::cassandra_type::CassandraType;
+
+                let values = self
+                    .data
+                    .iter()
+                    .map(|(col_type, bytes)| {
+                        let wrapper = self.get_wrapper_fn(col_type.clone());
+                        wrapper(&bytes)
+                    })
+                    .collect();
+
+                Ok(Some(CassandraType::Tuple(values)))
+            }
+        }
+    };
+}
+
 macro_rules! map_as_rust {
     ({ $($key_type:tt)+ }, { $($val_type:tt)+ }) => (
         impl AsRustType<HashMap<$($key_type)+, $($val_type)+>> for Map {

--- a/cassandra-protocol/src/macros.rs
+++ b/cassandra-protocol/src/macros.rs
@@ -142,6 +142,29 @@ macro_rules! tuple_as_cassandra_type {
     };
 }
 
+macro_rules! udt_as_cassandra_type {
+    () => {
+        impl crate::types::AsCassandraType for Udt {
+            fn as_cassandra_type(
+                &self,
+            ) -> Result<Option<crate::types::cassandra_type::CassandraType>> {
+                use crate::types::cassandra_type::CassandraType;
+                use std::collections::HashMap;
+
+                let mut map = HashMap::new();
+
+                self.data.iter().for_each(|(key, (col_type, bytes))| {
+                    let wrapper = self.get_wrapper_fn(col_type.clone());
+                    let value = wrapper(&bytes);
+                    map.insert(key.clone(), value);
+                });
+
+                Ok(Some(CassandraType::Udt(map)))
+            }
+        }
+    };
+}
+
 macro_rules! map_as_rust {
     ({ $($key_type:tt)+ }, { $($val_type:tt)+ }) => (
         impl AsRustType<HashMap<$($key_type)+, $($val_type)+>> for Map {

--- a/cassandra-protocol/src/types.rs
+++ b/cassandra-protocol/src/types.rs
@@ -54,68 +54,165 @@ pub trait AsCassandraType {
     fn get_wrapper_fn(&self, col_type: ColTypeOption) -> Box<dyn Fn(&CBytes) -> CassandraType> {
         match col_type.id {
             ColType::Blob => Box::new(move |bytes: &CBytes| {
-                CassandraType::Blob(as_rust_type!(col_type, bytes, Blob).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, Blob).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Blob(t),
+                    None => CassandraType::Null,
+                }
             }),
 
             ColType::Ascii => Box::new(move |bytes: &CBytes| {
-                CassandraType::Ascii(as_rust_type!(col_type, bytes, String).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, String).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Ascii(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Int => Box::new(move |bytes: &CBytes| {
-                CassandraType::Int(as_rust_type!(col_type, bytes, i32).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, i32).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Int(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::List => Box::new(move |bytes| {
-                let list = as_rust_type!(col_type, bytes, List).unwrap().unwrap();
-
-                list.as_cassandra_type().unwrap().unwrap()
+                let list = as_rust_type!(col_type, bytes, List).unwrap();
+                match list {
+                    Some(t) => t.as_cassandra_type().unwrap().unwrap(),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Custom => todo!(),
             ColType::Bigint => Box::new(move |bytes| {
-                CassandraType::Bigint(as_rust_type!(col_type, bytes, BigInt).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, BigInt).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Bigint(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Boolean => Box::new(move |bytes| {
-                CassandraType::Boolean(as_rust_type!(col_type, bytes, bool).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, bool).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Boolean(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Counter => Box::new(move |bytes| {
-                CassandraType::Counter(as_rust_type!(col_type, bytes, i64).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, i64).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Counter(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Decimal => Box::new(move |bytes| {
-                CassandraType::Decimal(as_rust_type!(col_type, bytes, Decimal).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, Decimal).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Decimal(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Double => Box::new(move |bytes| {
-                CassandraType::Double(as_rust_type!(col_type, bytes, f64).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, f64).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Double(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Float => Box::new(move |bytes| {
-                CassandraType::Float(as_rust_type!(col_type, bytes, f32).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, f32).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Float(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Timestamp => Box::new(move |bytes| {
-                CassandraType::Timestamp(as_rust_type!(col_type, bytes, i64).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, i64).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Timestamp(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Uuid => Box::new(move |bytes| {
-                CassandraType::Uuid(as_rust_type!(col_type, bytes, Uuid).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, Uuid).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Uuid(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Varchar => Box::new(move |bytes| {
-                CassandraType::Varchar(as_rust_type!(col_type, bytes, String).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, String).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Varchar(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Varint => Box::new(move |bytes| {
-                CassandraType::Varint(as_rust_type!(col_type, bytes, BigInt).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, BigInt).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Varint(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Timeuuid => Box::new(move |bytes| {
-                CassandraType::Timeuuid(as_rust_type!(col_type, bytes, Uuid).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, Uuid).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Timeuuid(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Inet => Box::new(move |bytes| {
-                CassandraType::Inet(as_rust_type!(col_type, bytes, IpAddr).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, IpAddr).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Inet(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Date => Box::new(move |bytes| {
-                CassandraType::Date(as_rust_type!(col_type, bytes, i32).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, i32).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Date(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Time => Box::new(move |bytes| {
-                CassandraType::Time(as_rust_type!(col_type, bytes, i64).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, i64).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Time(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Smallint => Box::new(move |bytes| {
-                CassandraType::Smallint(as_rust_type!(col_type, bytes, i16).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, i16).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Smallint(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Tinyint => Box::new(move |bytes| {
-                CassandraType::Tinyint(as_rust_type!(col_type, bytes, i8).unwrap().unwrap())
+                let t = as_rust_type!(col_type, bytes, i8).unwrap();
+
+                match t {
+                    Some(t) => CassandraType::Tinyint(t),
+                    None => CassandraType::Null,
+                }
             }),
             ColType::Map => todo!(),
             ColType::Set => todo!(),

--- a/cassandra-protocol/src/types/cassandra_type.rs
+++ b/cassandra-protocol/src/types/cassandra_type.rs
@@ -4,7 +4,7 @@ use std::net::IpAddr;
 
 use super::prelude::{Blob, Decimal};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum CassandraType {
     Ascii(String),
     Bigint(BigInt),

--- a/cassandra-protocol/src/types/cassandra_type.rs
+++ b/cassandra-protocol/src/types/cassandra_type.rs
@@ -32,3 +32,191 @@ pub enum CassandraType {
     Tuple(Vec<CassandraType>),
     Null,
 }
+
+pub mod wrappers {
+    use super::CassandraType;
+    use crate::frame::frame_result::{ColType, ColTypeOption, ColTypeOptionValue};
+    use crate::types::data_serialization_types::*;
+    use crate::types::list::List;
+    use crate::types::AsCassandraType;
+    use crate::types::CBytes;
+
+    pub fn blob(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, Blob).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Blob(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn ascii(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, String).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Ascii(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn int(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, i32).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Int(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn list(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let list = as_rust_type!(col_type, bytes, List).unwrap();
+        match list {
+            Some(t) => t.as_cassandra_type().unwrap().unwrap(),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn bigint(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, BigInt).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Bigint(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn counter(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, i64).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Counter(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn decimal(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, Decimal).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Decimal(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn double(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, f64).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Double(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn float(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, f32).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Float(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn timestamp(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, i64).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Timestamp(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn uuid(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, Uuid).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Uuid(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn varchar(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, String).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Varchar(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn varint(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, BigInt).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Varint(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn timeuuid(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, Uuid).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Timeuuid(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn inet(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, IpAddr).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Inet(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn date(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, i32).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Date(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn time(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, i64).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Time(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn smallint(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, i16).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Smallint(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn tinyint(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, i8).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Tinyint(t),
+            None => CassandraType::Null,
+        }
+    }
+
+    pub fn bool(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+        let t = as_rust_type!(col_type, bytes, bool).unwrap();
+
+        match t {
+            Some(t) => CassandraType::Boolean(t),
+            None => CassandraType::Null,
+        }
+    }
+}

--- a/cassandra-protocol/src/types/cassandra_type.rs
+++ b/cassandra-protocol/src/types/cassandra_type.rs
@@ -1,0 +1,34 @@
+use num::BigInt;
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+use super::prelude::{Blob, Decimal};
+
+#[derive(Debug)]
+pub enum CassandraType {
+    Ascii(String),
+    Bigint(BigInt),
+    Blob(Blob),
+    Boolean(bool),
+    Counter(i64),
+    Decimal(Decimal),
+    Double(f64),
+    Float(f32),
+    Int(i32),
+    Timestamp(i64),
+    Uuid(uuid::Uuid),
+    Varchar(String),
+    Varint(BigInt),
+    Timeuuid(uuid::Uuid),
+    Inet(IpAddr),
+    Date(i32),
+    Time(i64),
+    Smallint(i16),
+    Tinyint(i8),
+    List(Vec<CassandraType>),
+    Map(Vec<(CassandraType, CassandraType)>),
+    Set(Vec<CassandraType>),
+    Udt(HashMap<String, CassandraType>),
+    Tuple(Vec<CassandraType>),
+    Null,
+}

--- a/cassandra-protocol/src/types/data_serialization_types.rs
+++ b/cassandra-protocol/src/types/data_serialization_types.rs
@@ -242,7 +242,6 @@ pub fn decode_tuple(bytes: &[u8], l: usize) -> Result<Vec<CBytes>, io::Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::error::*;
     use super::super::super::frame::frame_result::*;
     use super::*;
     use crate::types::{to_float, to_float_big};

--- a/cassandra-protocol/src/types/list.rs
+++ b/cassandra-protocol/src/types/list.rs
@@ -50,3 +50,5 @@ list_as_rust!(Udt);
 list_as_rust!(Tuple);
 list_as_rust!(Decimal);
 list_as_rust!(BigInt);
+
+list_as_cassandra_type!();

--- a/cassandra-protocol/src/types/map.rs
+++ b/cassandra-protocol/src/types/map.rs
@@ -245,3 +245,5 @@ map_as_rust!({ Tuple }, { Udt });
 map_as_rust!({ Tuple }, { Tuple });
 map_as_rust!({ Tuple }, { Decimal });
 map_as_rust!({ Tuple }, { BigInt });
+
+map_as_cassandra_type!();

--- a/cassandra-protocol/src/types/tuple.rs
+++ b/cassandra-protocol/src/types/tuple.rs
@@ -81,3 +81,5 @@ into_rust_by_index!(Tuple, Decimal);
 into_rust_by_index!(Tuple, NaiveDateTime);
 into_rust_by_index!(Tuple, DateTime<Utc>);
 into_rust_by_index!(Tuple, BigInt);
+
+tuple_as_cassandra_type!();

--- a/cassandra-protocol/src/types/udt.rs
+++ b/cassandra-protocol/src/types/udt.rs
@@ -60,3 +60,5 @@ into_rust_by_name!(Udt, NonZeroI64);
 into_rust_by_name!(Udt, NaiveDateTime);
 into_rust_by_name!(Udt, DateTime<Utc>);
 into_rust_by_name!(Udt, BigInt);
+
+udt_as_cassandra_type!();

--- a/cassandra-protocol/src/types/value.rs
+++ b/cassandra-protocol/src/types/value.rs
@@ -7,6 +7,7 @@ use std::net::IpAddr;
 use std::num::{NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8};
 
 use chrono::prelude::*;
+use num::BigInt;
 use time::PrimitiveDateTime;
 use uuid::Uuid;
 
@@ -281,6 +282,12 @@ impl<T: Into<Bytes>> From<Vec<T>> for Bytes {
         }
 
         Bytes(bytes)
+    }
+}
+
+impl From<BigInt> for Bytes {
+    fn from(value: BigInt) -> Self {
+        Self(value.serialize_to_vec())
     }
 }
 


### PR DESCRIPTION
Adds the ability to parse a collection into usable types without knowing the type that the collection is supposed to be storing beforehand.

### An example of the usecase: 

#### Detecting we have a `List but don't know the type of it yet.
https://github.com/conorbros/shotover-proxy/blob/d51d063da82ade4828309e921848529892159cfc/shotover-proxy/src/message/mod.rs#L458

#### Parse our `List` with `CassandraType` enums into another type for our internal uses
https://github.com/conorbros/shotover-proxy/blob/d51d063da82ade4828309e921848529892159cfc/shotover-proxy/src/message/mod.rs#L595

#### Pattern matching our elements of valid Cassandra types into our internal type
https://github.com/conorbros/shotover-proxy/blob/d51d063da82ade4828309e921848529892159cfc/shotover-proxy/src/message/mod.rs#L562