### PR TITLE
Export get_wrapper_fn and add functions for wrapping collections

### DIFF
--- a/cassandra-protocol/src/macros.rs
+++ b/cassandra-protocol/src/macros.rs
@@ -62,6 +62,7 @@ macro_rules! list_as_cassandra_type {
                 &self,
             ) -> Result<Option<crate::types::cassandra_type::CassandraType>> {
                 use crate::error::Error;
+                use crate::types::cassandra_type::get_wrapper_fn;
                 use crate::types::cassandra_type::CassandraType;
                 use std::ops::Deref;
 
@@ -69,9 +70,7 @@ macro_rules! list_as_cassandra_type {
                     Some(ColTypeOptionValue::CList(ref type_option))
                     | Some(ColTypeOptionValue::CSet(ref type_option)) => {
                         let type_option_ref = type_option.deref().clone();
-                        let wrapper = <List as crate::types::AsCassandraType>::get_wrapper_fn(
-                            &type_option_ref,
-                        );
+                        let wrapper = get_wrapper_fn(&type_option_ref.id);
                         let convert = self.map(|bytes| wrapper(bytes, &type_option_ref));
                         Ok(Some(CassandraType::List(convert)))
                     }
@@ -92,6 +91,7 @@ macro_rules! map_as_cassandra_type {
             fn as_cassandra_type(
                 &self,
             ) -> Result<Option<crate::types::cassandra_type::CassandraType>> {
+                use crate::types::cassandra_type::get_wrapper_fn;
                 use crate::types::cassandra_type::CassandraType;
                 use std::ops::Deref;
 
@@ -103,13 +103,9 @@ macro_rules! map_as_cassandra_type {
                     let key_col_type_option = key_col_type_option.deref().clone();
                     let value_col_type_option = value_col_type_option.deref().clone();
 
-                    let key_wrapper = <Map as crate::types::AsCassandraType>::get_wrapper_fn(
-                        &key_col_type_option,
-                    );
+                    let key_wrapper = get_wrapper_fn(&key_col_type_option.id);
 
-                    let value_wrapper = <Map as crate::types::AsCassandraType>::get_wrapper_fn(
-                        &value_col_type_option,
-                    );
+                    let value_wrapper = get_wrapper_fn(&value_col_type_option.id);
 
                     let map = self
                         .data
@@ -137,14 +133,14 @@ macro_rules! tuple_as_cassandra_type {
             fn as_cassandra_type(
                 &self,
             ) -> Result<Option<crate::types::cassandra_type::CassandraType>> {
+                use crate::types::cassandra_type::get_wrapper_fn;
                 use crate::types::cassandra_type::CassandraType;
 
                 let values = self
                     .data
                     .iter()
                     .map(|(col_type, bytes)| {
-                        let wrapper =
-                            <Tuple as crate::types::AsCassandraType>::get_wrapper_fn(&col_type);
+                        let wrapper = get_wrapper_fn(&col_type.id);
                         wrapper(&bytes, col_type)
                     })
                     .collect();
@@ -161,13 +157,14 @@ macro_rules! udt_as_cassandra_type {
             fn as_cassandra_type(
                 &self,
             ) -> Result<Option<crate::types::cassandra_type::CassandraType>> {
+                use crate::types::cassandra_type::get_wrapper_fn;
                 use crate::types::cassandra_type::CassandraType;
                 use std::collections::HashMap;
 
                 let mut map = HashMap::new();
 
                 self.data.iter().for_each(|(key, (col_type, bytes))| {
-                    let wrapper = <Udt as crate::types::AsCassandraType>::get_wrapper_fn(&col_type);
+                    let wrapper = get_wrapper_fn(&col_type.id);
                     let value = wrapper(&bytes, col_type);
                     map.insert(key.clone(), value);
                 });

--- a/cassandra-protocol/src/types.rs
+++ b/cassandra-protocol/src/types.rs
@@ -5,12 +5,11 @@ use std::io::{Cursor, Read};
 use std::net::{IpAddr, SocketAddr};
 
 use crate::error::{column_is_empty_err, Error as CdrsError, Result as CDRSResult};
-use crate::frame::frame_result::{ColType, ColTypeOption};
 use crate::frame::traits::FromCursor;
 use crate::frame::Serialize;
 use crate::types::data_serialization_types::*;
 
-use self::cassandra_type::{wrappers, CassandraType};
+use self::cassandra_type::CassandraType;
 
 pub const SHORT_LEN: usize = 2;
 pub const INT_LEN: usize = 4;
@@ -49,39 +48,6 @@ pub mod prelude {
 
 pub trait AsCassandraType {
     fn as_cassandra_type(&self) -> CDRSResult<Option<CassandraType>>;
-
-    fn get_wrapper_fn(
-        col_type: &ColTypeOption,
-    ) -> &'static dyn Fn(&CBytes, &ColTypeOption) -> CassandraType {
-        match col_type.id {
-            ColType::Blob => &wrappers::blob,
-            ColType::Ascii => &wrappers::ascii,
-            ColType::Int => &wrappers::int,
-            ColType::List => &wrappers::list,
-            ColType::Custom => todo!(),
-            ColType::Bigint => &wrappers::bigint,
-            ColType::Boolean => &wrappers::bool,
-            ColType::Counter => &wrappers::counter,
-            ColType::Decimal => &wrappers::decimal,
-            ColType::Double => &wrappers::double,
-            ColType::Float => &wrappers::float,
-            ColType::Timestamp => &wrappers::timestamp,
-            ColType::Uuid => &wrappers::uuid,
-            ColType::Varchar => &wrappers::varchar,
-            ColType::Varint => &wrappers::varint,
-            ColType::Timeuuid => &wrappers::timeuuid,
-            ColType::Inet => &wrappers::inet,
-            ColType::Date => &wrappers::date,
-            ColType::Time => &wrappers::time,
-            ColType::Smallint => &wrappers::smallint,
-            ColType::Tinyint => &wrappers::tinyint,
-            ColType::Map => todo!(),
-            ColType::Set => todo!(),
-            ColType::Udt => todo!(),
-            ColType::Tuple => todo!(),
-            ColType::Null => todo!(),
-        }
-    }
 }
 
 /// Should be used to represent a single column as a Rust value.

--- a/cassandra-protocol/src/types/cassandra_type.rs
+++ b/cassandra-protocol/src/types/cassandra_type.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use super::prelude::{Blob, Decimal};
+use crate::error::Result as CDRSResult;
 use crate::frame::frame_result::{ColType, ColTypeOption};
 use crate::types::CBytes;
 
@@ -36,9 +37,9 @@ pub enum CassandraType {
 }
 
 /// Get a function to convert `CBytes` and `ColTypeOption` into a `CassandraType`
-pub fn get_wrapper_fn(
+pub fn wrapper_fn(
     col_type: &ColType,
-) -> &'static dyn Fn(&CBytes, &ColTypeOption) -> CassandraType {
+) -> &'static dyn Fn(&CBytes, &ColTypeOption) -> CDRSResult<CassandraType> {
     match col_type {
         ColType::Blob => &wrappers::blob,
         ColType::Ascii => &wrappers::ascii,
@@ -71,6 +72,7 @@ pub fn get_wrapper_fn(
 
 pub mod wrappers {
     use super::CassandraType;
+    use crate::error::Result as CDRSResult;
     use crate::frame::frame_result::{ColType, ColTypeOption, ColTypeOptionValue};
     use crate::types::data_serialization_types::*;
     use crate::types::list::List;
@@ -78,244 +80,240 @@ pub mod wrappers {
     use crate::types::CBytes;
     use crate::types::{map::Map, tuple::Tuple, udt::Udt};
 
-    pub fn map(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+    pub fn map(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
         if let Some(actual_bytes) = bytes.as_slice() {
-            let decoded_map = decode_map(actual_bytes).unwrap();
+            let decoded_map = decode_map(actual_bytes)?;
 
-            Map::new(decoded_map, col_type.clone())
-                .as_cassandra_type()
-                .unwrap()
-                .unwrap()
+            Ok(Map::new(decoded_map, col_type.clone())
+                .as_cassandra_type()?
+                .unwrap_or(CassandraType::Null))
         } else {
-            CassandraType::Null
+            Ok(CassandraType::Null)
         }
     }
 
-    pub fn set(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+    pub fn set(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
         if let Some(actual_bytes) = bytes.as_slice() {
-            let decoded_set = decode_set(actual_bytes).unwrap();
+            let decoded_set = decode_set(actual_bytes)?;
 
-            List::new(col_type.clone(), decoded_set)
-                .as_cassandra_type()
-                .unwrap()
-                .unwrap()
+            Ok(List::new(col_type.clone(), decoded_set)
+                .as_cassandra_type()?
+                .unwrap_or(CassandraType::Null))
         } else {
-            CassandraType::Null
+            Ok(CassandraType::Null)
         }
     }
 
-    pub fn udt(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+    pub fn udt(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
         if let Some(ColTypeOptionValue::UdtType(ref list_type_option)) = col_type.value {
             if let Some(actual_bytes) = bytes.as_slice() {
                 let len = list_type_option.descriptions.len();
-                let decoded_udt = decode_udt(actual_bytes, len).unwrap();
+                let decoded_udt = decode_udt(actual_bytes, len)?;
 
-                return Udt::new(decoded_udt, list_type_option)
-                    .as_cassandra_type()
-                    .unwrap()
-                    .unwrap();
+                return Ok(Udt::new(decoded_udt, list_type_option)
+                    .as_cassandra_type()?
+                    .unwrap_or(CassandraType::Null));
             }
         }
 
-        CassandraType::Null
+        Ok(CassandraType::Null)
     }
 
-    pub fn tuple(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
+    pub fn tuple(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
         if let Some(ColTypeOptionValue::TupleType(ref list_type_option)) = col_type.value {
             if let Some(actual_bytes) = bytes.as_slice() {
                 let len = list_type_option.types.len();
-                let decoded_tuple = decode_tuple(actual_bytes, len).unwrap();
+                let decoded_tuple = decode_tuple(actual_bytes, len)?;
 
-                return Tuple::new(decoded_tuple, list_type_option)
-                    .as_cassandra_type()
-                    .unwrap()
-                    .unwrap();
+                return Ok(Tuple::new(decoded_tuple, list_type_option)
+                    .as_cassandra_type()?
+                    .unwrap_or(CassandraType::Null));
             }
         }
 
-        CassandraType::Null
+        Ok(CassandraType::Null)
     }
 
-    pub fn null(_: &CBytes, _col_type: &ColTypeOption) -> CassandraType {
-        CassandraType::Null
+    pub fn null(_: &CBytes, _col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        Ok(CassandraType::Null)
     }
 
-    pub fn blob(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, Blob).unwrap();
+    pub fn blob(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, Blob)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Blob(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn ascii(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, String).unwrap();
+    pub fn ascii(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, String)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Ascii(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn int(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, i32).unwrap();
+    pub fn int(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, i32)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Int(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn list(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let list = as_rust_type!(col_type, bytes, List).unwrap();
-        match list {
-            Some(t) => t.as_cassandra_type().unwrap().unwrap(),
+    pub fn list(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let list = as_rust_type!(col_type, bytes, List)?;
+        Ok(match list {
+            Some(t) => t.as_cassandra_type()?.unwrap_or(CassandraType::Null),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn bigint(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, i64).unwrap();
+    pub fn bigint(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, i64)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Bigint(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn counter(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, i64).unwrap();
+    pub fn counter(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, i64)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Counter(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn decimal(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, Decimal).unwrap();
+    pub fn decimal(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, Decimal)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Decimal(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn double(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, f64).unwrap();
+    pub fn double(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, f64)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Double(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn float(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, f32).unwrap();
+    pub fn float(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, f32)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Float(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn timestamp(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, i64).unwrap();
+    pub fn timestamp(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, i64)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Timestamp(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn uuid(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, Uuid).unwrap();
+    pub fn uuid(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, Uuid)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Uuid(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn varchar(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, String).unwrap();
+    pub fn varchar(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, String)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Varchar(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn varint(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, BigInt).unwrap();
+    pub fn varint(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, BigInt)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Varint(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn timeuuid(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, Uuid).unwrap();
+    pub fn timeuuid(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, Uuid)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Timeuuid(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn inet(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, IpAddr).unwrap();
+    pub fn inet(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, IpAddr)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Inet(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn date(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, i32).unwrap();
+    pub fn date(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, i32)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Date(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn time(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, i64).unwrap();
+    pub fn time(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, i64)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Time(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn smallint(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, i16).unwrap();
+    pub fn smallint(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, i16)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Smallint(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn tinyint(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, i8).unwrap();
+    pub fn tinyint(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, i8)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Tinyint(t),
             None => CassandraType::Null,
-        }
+        })
     }
 
-    pub fn bool(bytes: &CBytes, col_type: &ColTypeOption) -> CassandraType {
-        let t = as_rust_type!(col_type, bytes, bool).unwrap();
+    pub fn bool(bytes: &CBytes, col_type: &ColTypeOption) -> CDRSResult<CassandraType> {
+        let t = as_rust_type!(col_type, bytes, bool)?;
 
-        match t {
+        Ok(match t {
             Some(t) => CassandraType::Boolean(t),
             None => CassandraType::Null,
-        }
+        })
     }
 }

--- a/cassandra-protocol/src/types/cassandra_type.rs
+++ b/cassandra-protocol/src/types/cassandra_type.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use super::prelude::{Blob, Decimal};
+use crate::frame::frame_result::{ColType, ColTypeOption};
+use crate::types::CBytes;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum CassandraType {
@@ -31,6 +33,40 @@ pub enum CassandraType {
     Udt(HashMap<String, CassandraType>),
     Tuple(Vec<CassandraType>),
     Null,
+}
+
+/// Get a function to convert `CBytes` and `ColTypeOption` into a `CassandraType`
+pub fn get_wrapper_fn(
+    col_type: &ColType,
+) -> &'static dyn Fn(&CBytes, &ColTypeOption) -> CassandraType {
+    match col_type {
+        ColType::Blob => &wrappers::blob,
+        ColType::Ascii => &wrappers::ascii,
+        ColType::Int => &wrappers::int,
+        ColType::List => &wrappers::list,
+        ColType::Custom => todo!(),
+        ColType::Bigint => &wrappers::bigint,
+        ColType::Boolean => &wrappers::bool,
+        ColType::Counter => &wrappers::counter,
+        ColType::Decimal => &wrappers::decimal,
+        ColType::Double => &wrappers::double,
+        ColType::Float => &wrappers::float,
+        ColType::Timestamp => &wrappers::timestamp,
+        ColType::Uuid => &wrappers::uuid,
+        ColType::Varchar => &wrappers::varchar,
+        ColType::Varint => &wrappers::varint,
+        ColType::Timeuuid => &wrappers::timeuuid,
+        ColType::Inet => &wrappers::inet,
+        ColType::Date => &wrappers::date,
+        ColType::Time => &wrappers::time,
+        ColType::Smallint => &wrappers::smallint,
+        ColType::Tinyint => &wrappers::tinyint,
+        ColType::Map => todo!(),
+        ColType::Set => todo!(),
+        ColType::Udt => todo!(),
+        ColType::Tuple => todo!(),
+        ColType::Null => todo!(),
+    }
 }
 
 pub mod wrappers {


### PR DESCRIPTION
- useful if you want to create `CassandraType`'s yourself
- All types are now convertible except for Custom. 