### PR TITLE
remove into_plain in favour of into_bytes

### DIFF
--- a/cassandra-protocol/src/types.rs
+++ b/cassandra-protocol/src/types.rs
@@ -290,7 +290,7 @@ impl CBytes {
 
     /// Converts `CBytes` into a plain array of bytes
     #[inline]
-    pub fn into_plain(self) -> Option<Vec<u8>> {
+    pub fn into_bytes(self) -> Option<Vec<u8>> {
         self.bytes
     }
 
@@ -305,11 +305,6 @@ impl CBytes {
             None => true,
             Some(bytes) => bytes.is_empty(),
         }
-    }
-
-    #[inline]
-    pub fn into_bytes(self) -> Option<Vec<u8>> {
-        self.bytes
     }
 }
 
@@ -352,9 +347,9 @@ impl CBytesShort {
         CBytesShort { bytes: Some(bytes) }
     }
 
-    /// Converts `CBytesShort` into plain vector of bytes;
+    /// Converts `CBytesShort` into plain vector of bytes
     #[inline]
-    pub fn into_plain(self) -> Option<Vec<u8>> {
+    pub fn into_bytes(self) -> Option<Vec<u8>> {
         self.bytes
     }
 
@@ -568,7 +563,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cbytes_into_plain() {
+    fn test_cbytes_into_bytes() {
         let cbytes = CBytes::new(vec![1, 2, 3]);
         assert_eq!(cbytes.into_bytes().unwrap(), &[1, 2, 3]);
     }
@@ -596,9 +591,9 @@ mod tests {
     }
 
     #[test]
-    fn test_cbytesshort_into_plain() {
+    fn test_cbytesshort_into_bytes() {
         let cbytes = CBytesShort::new(vec![1, 2, 3]);
-        assert_eq!(cbytes.into_plain().unwrap(), vec![1, 2, 3]);
+        assert_eq!(cbytes.into_bytes().unwrap(), vec![1, 2, 3]);
     }
 
     #[test]
@@ -606,7 +601,7 @@ mod tests {
         let a = &[0, 3, 1, 2, 3];
         let mut cursor: Cursor<&[u8]> = Cursor::new(a);
         let cbytes = CBytesShort::from_cursor(&mut cursor).unwrap();
-        assert_eq!(cbytes.into_plain().unwrap(), vec![1, 2, 3]);
+        assert_eq!(cbytes.into_bytes().unwrap(), vec![1, 2, 3]);
     }
 
     #[test]

--- a/cassandra-protocol/src/types.rs
+++ b/cassandra-protocol/src/types.rs
@@ -306,6 +306,12 @@ impl CBytes {
             Some(bytes) => bytes.is_empty(),
         }
     }
+
+    #[inline]
+    #[deprecated(note = "Use into_bytes().")]
+    pub fn into_plain(self) -> Option<Vec<u8>> {
+        self.bytes
+    }
 }
 
 impl FromCursor for CBytes {
@@ -361,6 +367,12 @@ impl CBytesShort {
             } else {
                 0
             }
+    }
+
+    #[inline]
+    #[deprecated(note = "Use into_bytes().")]
+    pub fn into_plain(self) -> Option<Vec<u8>> {
+        self.bytes
     }
 }
 


### PR DESCRIPTION
Both methods do the same thing so I have removed `into_plain` in favour of `into_bytes` as it is more descriptive to me. Happy to switch around though, or maybe just deprecate `into_plain` if we don't want to release a breaking change.