### PR TITLE
Configuration of replication strategy parsing fix.

### DIFF
--- a/cdrs-tokio/Cargo.toml
+++ b/cdrs-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cdrs-tokio"
-version = "6.0.0"
+version = "6.0.1"
 authors = ["Alex Pikalov <alex.pikalov.khar@gmail.com>", "Kamil Rojewski <kamil.rojewski@gmail.com>"]
 edition = "2018"
 description = "Async Cassandra DB driver written in Rust"


### PR DESCRIPTION
The `class` property obviously can't be parsed by `extract_replication_factor`. I fixed parsing, but it's still not type safe, maybe I make a few MR later.