### PR TITLE
Move docs on BatchQuery::values onto QueryValues::NamedValues

### DIFF
--- a/cassandra-protocol/src/frame/frame_batch.rs
+++ b/cassandra-protocol/src/frame/frame_batch.rs
@@ -145,10 +145,8 @@ pub struct BatchQuery {
     pub is_prepared: bool,
     /// Contains either id of prepared query or a query itself.
     pub subject: BatchQuerySubj,
-    /// It is the optional name of the following <value_i>. It must be present
-    /// if and only if the 0x40 flag is provided for the batch.
-    /// **Important note:** this feature does not work and should not be
-    /// used. It is specified in a way that makes it impossible for the server
+    /// **Important note:** QueryValues::NamedValues does not work and should not be
+    /// used for batches. It is specified in a way that makes it impossible for the server
     /// to implement. This will be fixed in a future version of the native
     /// protocol. See <https://issues.apache.org/jira/browse/CASSANDRA-10246> for
     /// more details


### PR DESCRIPTION
The warning only applies to the NamedValues variant of QueryValues.
I also left off the implementation details that the user doesnt need to know.