### PR TITLE
Update uuid to 1.0

### DIFF
--- a/cassandra-protocol/Cargo.toml
+++ b/cassandra-protocol/Cargo.toml
@@ -25,5 +25,5 @@ lz4_flex = "0.9"
 snap = "1"
 thiserror = "1"
 time = { version = "0.3", features = ["std", "macros"] }
-uuid = "0.8"
+uuid = "1.0"
 derivative = "2.2.0"

--- a/cdrs-tokio/Cargo.toml
+++ b/cdrs-tokio/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0"
 tokio = { version = "1", features = ["net", "io-util", "rt", "sync", "macros", "rt-multi-thread", "time"] }
 tokio-rustls = { version = "0.23", optional = true }
 tracing = "0.1"
-uuid = "0.8"
+uuid = "1.0"
 webpki = { version = "0.22", optional = true }
 
 [dependencies.rustls]
@@ -46,5 +46,5 @@ maplit = "1.0.0"
 mockall = "0.11"
 lazy_static = "1.4"
 regex = "1.5"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 time = { version = "0.3", features = ["std", "macros"] }


### PR DESCRIPTION
This is a breaking change because uuid types are exposed in the public API