### PR TITLE
make logs less noisy

### DIFF
--- a/cdrs-tokio/Cargo.toml
+++ b/cdrs-tokio/Cargo.toml
@@ -23,6 +23,7 @@ bytes = "1.1"
 cassandra-protocol = { path = "../cassandra-protocol", version = "1" }
 cdrs-tokio-helpers-derive = { path = "../cdrs-tokio-helpers-derive", version = "4", optional = true }
 derive_more = "0.99"
+derivative = "2.1.1"
 futures = { version = "0.3", default_features = false, features = ["alloc"] }
 fxhash = "0.2"
 itertools = "0.10"

--- a/cdrs-tokio/src/cluster/node_info.rs
+++ b/cdrs-tokio/src/cluster/node_info.rs
@@ -1,15 +1,18 @@
 use cassandra_protocol::token::Murmur3Token;
+use derivative::Derivative;
 use derive_more::Constructor;
 use std::net::SocketAddr;
 use uuid::Uuid;
 
 /// Information about a node.
-#[derive(Debug, Constructor, Clone)]
+#[derive(Constructor, Clone, Derivative)]
+#[derivative(Debug)]
 pub struct NodeInfo {
     pub host_id: Uuid,
     pub broadcast_rpc_address: SocketAddr,
     pub broadcast_address: Option<SocketAddr>,
     pub datacenter: String,
+    #[derivative(Debug = "ignore")]
     pub tokens: Vec<Murmur3Token>,
     pub rack: String,
 }


### PR DESCRIPTION
The debug logs are very noisy if we include the tokens in the `NodeInfo` debug impl. 