### PR TITLE
change trace to debug

### DIFF
--- a/cdrs-tokio/src/cluster/cluster_metadata_manager.rs
+++ b/cdrs-tokio/src/cluster/cluster_metadata_manager.rs
@@ -344,7 +344,7 @@ impl<T: CdrsTransport + 'static, CM: ConnectionManager<T> + 'static> ClusterMeta
     }
 
     async fn process_event(&self, event: ServerEvent) {
-        trace!(?event);
+        debug!(?event);
 
         match event {
             ServerEvent::TopologyChange(event) => self.process_topology_event(event).await,


### PR DESCRIPTION
There is only one `trace!` level log, so this might as well be `debug!` level.