### PR TITLE
ResponseBody into error method

### DIFF
--- a/cassandra-protocol/src/frame/message_response.rs
+++ b/cassandra-protocol/src/frame/message_response.rs
@@ -141,4 +141,11 @@ impl ResponseBody {
             _ => None,
         }
     }
+
+    pub fn into_error(self) -> Option<ErrorBody> {
+        match self {
+            ResponseBody::Error(err) => Some(err),
+            _ => None,
+        }
+    }
 }


### PR DESCRIPTION
Adding this because I needed it and we have methods for all the other result types so makes sense having one for error too.