### PR TITLE
multithread example - wasn't in parallel

### DIFF
--- a/cdrs-tokio/examples/multiple_thread.rs
+++ b/cdrs-tokio/examples/multiple_thread.rs
@@ -32,12 +32,13 @@ async fn main() {
     create_keyspace(session.clone()).await;
     create_table(session.clone()).await;
 
-    for i in 0..20 {
+    let futures : Vec<tokio::task::JoinHandle<()>> = (0..20).into_iter().map(|i| {
         let thread_session = session.clone();
         tokio::spawn(insert_struct(thread_session, i))
-            .await
-            .expect("thread error");
-    }
+
+    }).collect();
+    
+    let _responses = futures::future::join_all(futures);
 
     select_struct(session).await;
 }


### PR DESCRIPTION
Before it was awaiting for each iteration to be done, therefore not in parallel.
I changed it to be in parallel

