### PR TITLE
Fix examples

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,5 +27,6 @@ jobs:
         run: cargo test --all-features --verbose -- --test-threads=1
       - name: Format check
         run: cargo fmt --all -- --check
+        # Ensure that all targets compile and pass clippy checks under every possible combination of features
       - name: Clippy check
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo install cargo-hack --version 0.5.18 && cargo hack --feature-powerset clippy --locked --release -- -D warnings

--- a/cassandra-protocol/src/compression.rs
+++ b/cassandra-protocol/src/compression.rs
@@ -184,6 +184,7 @@ impl<'a> From<&'a str> for Compression {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn test_compression_from_str() {
         let lz4 = "lz4";

--- a/cassandra-protocol/src/consistency.rs
+++ b/cassandra-protocol/src/consistency.rs
@@ -1,14 +1,13 @@
 #![warn(missing_docs)]
 //! The module contains Rust representation of Cassandra consistency levels.
+use crate::error;
+use crate::frame::{FromBytes, FromCursor, Serialize, Version};
+use crate::types::*;
 use derive_more::Display;
 use std::convert::{From, TryFrom, TryInto};
 use std::default::Default;
 use std::io;
 use std::str::FromStr;
-
-use crate::error;
-use crate::frame::{FromBytes, FromCursor, Serialize, Version};
-use crate::types::*;
 
 /// `Consistency` is an enum which represents Cassandra's consistency levels.
 /// To find more details about each consistency level please refer to the following documentation:

--- a/cassandra-protocol/src/error.rs
+++ b/cassandra-protocol/src/error.rs
@@ -1,3 +1,7 @@
+use crate::compression::CompressionError;
+use crate::frame::message_error::ErrorBody;
+use crate::frame::Opcode;
+use crate::types::{CInt, CIntShort};
 use std::fmt::{Debug, Display};
 use std::io;
 use std::net::SocketAddr;
@@ -6,11 +10,6 @@ use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 use thiserror::Error as ThisError;
 use uuid::Error as UuidError;
-
-use crate::compression::CompressionError;
-use crate::frame::message_error::ErrorBody;
-use crate::frame::Opcode;
-use crate::types::{CInt, CIntShort};
 
 pub type Result<T> = result::Result<T, Error>;
 

--- a/cassandra-protocol/src/frame.rs
+++ b/cassandra-protocol/src/frame.rs
@@ -1,3 +1,8 @@
+use crate::compression::{Compression, CompressionError};
+use crate::frame::message_request::RequestBody;
+use crate::frame::message_response::ResponseBody;
+use crate::types::data_serialization_types::decode_timeuuid;
+use crate::types::{from_cursor_string_list, try_i16_from_bytes, try_i32_from_bytes, UUID_LEN};
 use bitflags::bitflags;
 use derivative::Derivative;
 use derive_more::{Constructor, Display};
@@ -5,12 +10,6 @@ use std::convert::TryFrom;
 use std::io::Cursor;
 use thiserror::Error;
 use uuid::Uuid;
-
-use crate::compression::{Compression, CompressionError};
-use crate::frame::message_request::RequestBody;
-use crate::frame::message_response::ResponseBody;
-use crate::types::data_serialization_types::decode_timeuuid;
-use crate::types::{from_cursor_string_list, try_i16_from_bytes, try_i32_from_bytes, UUID_LEN};
 
 pub use crate::frame::traits::*;
 

--- a/cassandra-protocol/src/frame/events.rs
+++ b/cassandra-protocol/src/frame/events.rs
@@ -1,12 +1,11 @@
-use derive_more::Display;
-use std::cmp::PartialEq;
-use std::convert::TryFrom;
-use std::io::Cursor;
-
 use crate::frame::traits::FromCursor;
 use crate::frame::{Serialize, Version};
 use crate::types::{from_cursor_str, from_cursor_string_list, serialize_str, CInet, CIntShort};
 use crate::{error, Error};
+use derive_more::Display;
+use std::cmp::PartialEq;
+use std::convert::TryFrom;
+use std::io::Cursor;
 
 // Event types
 const TOPOLOGY_CHANGE: &str = "TOPOLOGY_CHANGE";

--- a/cassandra-protocol/src/frame/frame_decoder.rs
+++ b/cassandra-protocol/src/frame/frame_decoder.rs
@@ -1,7 +1,3 @@
-use lz4_flex::decompress;
-use std::convert::TryInto;
-use std::io;
-
 use crate::compression::{Compression, CompressionError};
 use crate::crc::{crc24, crc32};
 use crate::error::{Error, Result};
@@ -9,6 +5,9 @@ use crate::frame::{
     Envelope, ParseEnvelopeError, COMPRESSED_FRAME_HEADER_LENGTH, ENVELOPE_HEADER_LEN,
     FRAME_TRAILER_LENGTH, MAX_FRAME_SIZE, PAYLOAD_SIZE_LIMIT, UNCOMPRESSED_FRAME_HEADER_LENGTH,
 };
+use lz4_flex::decompress;
+use std::convert::TryInto;
+use std::io;
 
 #[inline]
 fn create_unexpected_self_contained_error() -> Error {

--- a/cassandra-protocol/src/frame/frame_encoder.rs
+++ b/cassandra-protocol/src/frame/frame_encoder.rs
@@ -1,11 +1,10 @@
-use lz4_flex::block::get_maximum_output_size;
-use lz4_flex::{compress, compress_into};
-
 use crate::crc::{crc24, crc32};
 use crate::frame::{
     COMPRESSED_FRAME_HEADER_LENGTH, FRAME_TRAILER_LENGTH, PAYLOAD_SIZE_LIMIT,
     UNCOMPRESSED_FRAME_HEADER_LENGTH,
 };
+use lz4_flex::block::get_maximum_output_size;
+use lz4_flex::{compress, compress_into};
 
 #[inline]
 fn put3b(buffer: &mut [u8], value: i32) {

--- a/cassandra-protocol/src/frame/message_auth_challenge.rs
+++ b/cassandra-protocol/src/frame/message_auth_challenge.rs
@@ -1,10 +1,8 @@
-use std::io::Cursor;
-
+use super::Serialize;
 use crate::error;
 use crate::frame::{FromCursor, Version};
 use crate::types::CBytes;
-
-use super::Serialize;
+use std::io::Cursor;
 
 /// Server authentication challenge.
 #[derive(Debug, PartialEq, Ord, PartialOrd, Eq, Hash, Clone)]

--- a/cassandra-protocol/src/frame/message_auth_response.rs
+++ b/cassandra-protocol/src/frame/message_auth_response.rs
@@ -1,9 +1,8 @@
-use derive_more::Constructor;
-use std::io::Cursor;
-
 use crate::error;
 use crate::frame::{Direction, Envelope, Flags, FromCursor, Opcode, Serialize, Version};
 use crate::types::CBytes;
+use derive_more::Constructor;
+use std::io::Cursor;
 
 #[derive(Debug, Constructor, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct BodyReqAuthResponse {

--- a/cassandra-protocol/src/frame/message_auth_response.rs
+++ b/cassandra-protocol/src/frame/message_auth_response.rs
@@ -7,7 +7,7 @@ use crate::types::CBytes;
 
 #[derive(Debug, Constructor, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct BodyReqAuthResponse {
-    data: CBytes,
+    pub data: CBytes,
 }
 
 impl Serialize for BodyReqAuthResponse {

--- a/cassandra-protocol/src/frame/message_auth_success.rs
+++ b/cassandra-protocol/src/frame/message_auth_success.rs
@@ -1,10 +1,8 @@
-use std::io::Cursor;
-
+use super::Serialize;
 use crate::error;
 use crate::frame::{FromCursor, Version};
 use crate::types::CBytes;
-
-use super::Serialize;
+use std::io::Cursor;
 
 /// `BodyReqAuthSuccess` is a envelope that represents a successful authentication response.
 #[derive(Debug, PartialEq, Ord, PartialOrd, Eq, Hash, Clone)]

--- a/cassandra-protocol/src/frame/message_authenticate.rs
+++ b/cassandra-protocol/src/frame/message_authenticate.rs
@@ -1,10 +1,8 @@
-use std::io::Cursor;
-
+use super::Serialize;
 use crate::error;
 use crate::frame::{FromCursor, Version};
 use crate::types::{from_cursor_str, serialize_str};
-
-use super::Serialize;
+use std::io::Cursor;
 
 /// A server authentication challenge.
 #[derive(Debug, PartialEq, Ord, PartialOrd, Eq, Hash, Clone)]

--- a/cassandra-protocol/src/frame/message_batch.rs
+++ b/cassandra-protocol/src/frame/message_batch.rs
@@ -1,7 +1,3 @@
-use derive_more::{Constructor, Display};
-use std::convert::{TryFrom, TryInto};
-use std::io::{Cursor, Read};
-
 use crate::consistency::Consistency;
 use crate::frame::{Direction, Envelope, Flags, FromCursor, Opcode, Serialize, Version};
 use crate::query::QueryFlags;
@@ -12,6 +8,9 @@ use crate::types::{
     CIntShort, CLong,
 };
 use crate::{error, Error};
+use derive_more::{Constructor, Display};
+use std::convert::{TryFrom, TryInto};
+use std::io::{Cursor, Read};
 
 #[derive(Debug, Clone, Constructor, PartialEq, Eq)]
 pub struct BodyReqBatch {
@@ -251,14 +250,13 @@ impl Envelope {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
-
     use crate::consistency::Consistency;
     use crate::frame::message_batch::{BatchQuery, BatchQuerySubj, BatchType, BodyReqBatch};
     use crate::frame::traits::Serialize;
     use crate::frame::{FromCursor, Version};
     use crate::query::QueryValues;
     use crate::types::prelude::Value;
+    use std::io::Cursor;
 
     #[test]
     fn should_deserialize_query() {

--- a/cassandra-protocol/src/frame/message_error.rs
+++ b/cassandra-protocol/src/frame/message_error.rs
@@ -1,16 +1,14 @@
-/// This modules contains [Cassandra's errors](<https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec>)
-/// which server could respond to client.
-use derive_more::Display;
-use std::collections::HashMap;
-use std::io::{Cursor, Read};
-
+use super::Serialize;
 use crate::consistency::Consistency;
 use crate::frame::traits::FromCursor;
 use crate::frame::Version;
 use crate::types::*;
 use crate::{error, Error};
-
-use super::Serialize;
+/// This modules contains [Cassandra's errors](<https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec>)
+/// which server could respond to client.
+use derive_more::Display;
+use std::collections::HashMap;
+use std::io::{Cursor, Read};
 
 /// CDRS error which could be returned by Cassandra server as a response. As in the specification,
 /// it contains an error code and an error message. Apart of those depending of type of error,

--- a/cassandra-protocol/src/frame/message_event.rs
+++ b/cassandra-protocol/src/frame/message_event.rs
@@ -1,9 +1,8 @@
-use std::io::Cursor;
-
 use crate::error;
 use crate::frame::events::ServerEvent;
 use crate::frame::Serialize;
 use crate::frame::{FromCursor, Version};
+use std::io::Cursor;
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct BodyResEvent {

--- a/cassandra-protocol/src/frame/message_execute.rs
+++ b/cassandra-protocol/src/frame/message_execute.rs
@@ -1,10 +1,9 @@
-use derive_more::Constructor;
-use std::io::Cursor;
-
 use crate::error;
 use crate::frame::{Direction, Envelope, Flags, FromCursor, Opcode, Serialize, Version};
 use crate::query::QueryParams;
 use crate::types::CBytesShort;
+use derive_more::Constructor;
+use std::io::Cursor;
 
 /// The structure that represents a body of a envelope of type `execute`.
 #[derive(Debug, Constructor, Eq, PartialEq)]
@@ -107,14 +106,13 @@ impl Envelope {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
-
     use crate::consistency::Consistency;
     use crate::frame::message_execute::BodyReqExecuteOwned;
     use crate::frame::traits::Serialize;
     use crate::frame::{FromCursor, Version};
     use crate::query::QueryParams;
     use crate::types::CBytesShort;
+    use std::io::Cursor;
 
     #[test]
     fn should_deserialize_body() {

--- a/cassandra-protocol/src/frame/message_execute.rs
+++ b/cassandra-protocol/src/frame/message_execute.rs
@@ -9,9 +9,9 @@ use crate::types::CBytesShort;
 /// The structure that represents a body of a envelope of type `execute`.
 #[derive(Debug, Constructor, Eq, PartialEq)]
 pub struct BodyReqExecute<'a> {
-    id: &'a CBytesShort,
-    result_metadata_id: Option<&'a CBytesShort>,
-    query_parameters: &'a QueryParams,
+    pub id: &'a CBytesShort,
+    pub result_metadata_id: Option<&'a CBytesShort>,
+    pub query_parameters: &'a QueryParams,
 }
 
 impl<'a> Serialize for BodyReqExecute<'a> {
@@ -43,9 +43,9 @@ impl<'a> Serialize for BodyReqExecute<'a> {
 /// The structure that represents an owned body of a envelope of type `execute`.
 #[derive(Debug, Constructor, Clone, Eq, PartialEq, Default)]
 pub struct BodyReqExecuteOwned {
-    id: CBytesShort,
-    result_metadata_id: Option<CBytesShort>,
-    query_parameters: QueryParams,
+    pub id: CBytesShort,
+    pub result_metadata_id: Option<CBytesShort>,
+    pub query_parameters: QueryParams,
 }
 
 impl FromCursor for BodyReqExecuteOwned {

--- a/cassandra-protocol/src/frame/message_options.rs
+++ b/cassandra-protocol/src/frame/message_options.rs
@@ -1,7 +1,6 @@
-use std::io::Cursor;
-
 use crate::error;
 use crate::frame::{Direction, Envelope, Flags, FromCursor, Opcode, Serialize, Version};
+use std::io::Cursor;
 
 /// The structure which represents a body of a envelope of type `options`.
 #[derive(Debug, Default, Ord, PartialOrd, Eq, PartialEq, Hash, Copy, Clone)]

--- a/cassandra-protocol/src/frame/message_prepare.rs
+++ b/cassandra-protocol/src/frame/message_prepare.rs
@@ -1,11 +1,10 @@
-use std::io::Cursor;
-
 use crate::error;
 use crate::frame::{Direction, Envelope, Flags, FromCursor, Opcode, Serialize, Version};
 use crate::query::PrepareFlags;
 use crate::types::{
     from_cursor_str, from_cursor_str_long, serialize_str, serialize_str_long, INT_LEN, SHORT_LEN,
 };
+use std::io::Cursor;
 
 /// Struct that represents a body of a envelope of type `prepare`
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Default)]
@@ -107,10 +106,9 @@ impl Envelope {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
-
     use crate::frame::message_prepare::BodyReqPrepare;
     use crate::frame::{FromCursor, Serialize, Version};
+    use std::io::Cursor;
 
     #[test]
     fn should_deserialize_body() {

--- a/cassandra-protocol/src/frame/message_query.rs
+++ b/cassandra-protocol/src/frame/message_query.rs
@@ -1,11 +1,10 @@
-use std::io::Cursor;
-
 use crate::consistency::Consistency;
 use crate::error;
 use crate::frame::traits::FromCursor;
 use crate::frame::{Direction, Envelope, Flags, Opcode, Serialize, Version};
 use crate::query::{Query, QueryParams, QueryValues};
 use crate::types::{from_cursor_str_long, serialize_str_long, CBytes, CInt, CLong, INT_LEN};
+use std::io::Cursor;
 
 /// Structure which represents body of Query request
 #[derive(Debug, PartialEq, Eq, Clone, Default)]

--- a/cassandra-protocol/src/frame/message_ready.rs
+++ b/cassandra-protocol/src/frame/message_ready.rs
@@ -1,7 +1,6 @@
-use std::io::Cursor;
-
 use crate::error;
 use crate::frame::{FromCursor, Serialize, Version};
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Default, Ord, PartialOrd, Eq, Hash)]
 pub struct BodyResReady;

--- a/cassandra-protocol/src/frame/message_register.rs
+++ b/cassandra-protocol/src/frame/message_register.rs
@@ -1,12 +1,11 @@
-use derive_more::Constructor;
-use itertools::Itertools;
-use std::convert::TryFrom;
-use std::io::Cursor;
-
 use crate::error;
 use crate::frame::events::SimpleServerEvent;
 use crate::frame::{Direction, Envelope, Flags, FromCursor, Opcode, Serialize, Version};
 use crate::types::{from_cursor_string_list, serialize_str_list};
+use derive_more::Constructor;
+use itertools::Itertools;
+use std::convert::TryFrom;
+use std::io::Cursor;
 
 /// The structure which represents a body of a envelope of type `register`.
 #[derive(Debug, Constructor, Default, Ord, PartialOrd, Eq, PartialEq, Hash, Clone)]
@@ -54,11 +53,10 @@ impl Envelope {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
-
     use crate::events::SimpleServerEvent;
     use crate::frame::message_register::BodyReqRegister;
     use crate::frame::{FromCursor, Version};
+    use std::io::Cursor;
 
     #[test]
     fn should_deserialize_body() {

--- a/cassandra-protocol/src/frame/message_result.rs
+++ b/cassandra-protocol/src/frame/message_result.rs
@@ -1,8 +1,3 @@
-use bitflags::bitflags;
-use derive_more::{Constructor, Display};
-use std::convert::{TryFrom, TryInto};
-use std::io::{Cursor, Error as IoError, Read};
-
 use crate::error;
 use crate::error::Error;
 use crate::frame::events::SchemaChange;
@@ -12,6 +7,10 @@ use crate::types::{
     from_cursor_str, serialize_str, try_i16_from_bytes, try_i32_from_bytes, try_u64_from_bytes,
     CBytes, CBytesShort, CInt, CIntShort, INT_LEN, SHORT_LEN,
 };
+use bitflags::bitflags;
+use derive_more::{Constructor, Display};
+use std::convert::{TryFrom, TryInto};
+use std::io::{Cursor, Error as IoError, Read};
 
 /// `ResultKind` is enum which represents types of result.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash, Display)]
@@ -1594,9 +1593,8 @@ mod prepared {
 
 #[cfg(test)]
 mod schema_change {
-    use crate::frame::events::{SchemaChangeOptions, SchemaChangeTarget, SchemaChangeType};
-
     use super::*;
+    use crate::frame::events::{SchemaChangeOptions, SchemaChangeTarget, SchemaChangeType};
 
     #[test]
     fn test_schema_change() {

--- a/cassandra-protocol/src/frame/message_startup.rs
+++ b/cassandra-protocol/src/frame/message_startup.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
-use std::io::Cursor;
-
 use crate::error;
 use crate::frame::{Direction, Envelope, Flags, FromCursor, Opcode, Serialize, Version};
 use crate::types::{from_cursor_str, serialize_str, CIntShort};
+use std::collections::HashMap;
+use std::io::Cursor;
 
 const CQL_VERSION: &str = "CQL_VERSION";
 const CQL_VERSION_VAL: &str = "3.0.0";

--- a/cassandra-protocol/src/frame/message_supported.rs
+++ b/cassandra-protocol/src/frame/message_supported.rs
@@ -1,11 +1,9 @@
-use std::collections::HashMap;
-use std::io::{Cursor, Read};
-
+use super::Serialize;
 use crate::error;
 use crate::frame::{FromCursor, Version};
 use crate::types::{from_cursor_str, from_cursor_string_list, serialize_str, CIntShort, SHORT_LEN};
-
-use super::Serialize;
+use std::collections::HashMap;
+use std::io::{Cursor, Read};
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct BodyResSupported {

--- a/cassandra-protocol/src/frame/traits.rs
+++ b/cassandra-protocol/src/frame/traits.rs
@@ -1,9 +1,8 @@
-use num::BigInt;
-use std::io::{Cursor, Write};
-
 use crate::error;
 use crate::frame::Version;
 use crate::query;
+use num::BigInt;
+use std::io::{Cursor, Write};
 
 /// Trait that should be implemented by all types that wish to be serialized to a buffer.
 pub trait Serialize {

--- a/cassandra-protocol/src/types.rs
+++ b/cassandra-protocol/src/types.rs
@@ -1,15 +1,13 @@
+use self::cassandra_type::CassandraType;
+use crate::error::{column_is_empty_err, Error as CdrsError, Result as CDRSResult};
+use crate::frame::traits::FromCursor;
+use crate::frame::{Serialize, Version};
+use crate::types::data_serialization_types::*;
 use derive_more::Constructor;
 use std::convert::TryInto;
 use std::io::{self, Write};
 use std::io::{Cursor, Read};
 use std::net::{IpAddr, SocketAddr};
-
-use crate::error::{column_is_empty_err, Error as CdrsError, Result as CDRSResult};
-use crate::frame::traits::FromCursor;
-use crate::frame::{Serialize, Version};
-use crate::types::data_serialization_types::*;
-
-use self::cassandra_type::CassandraType;
 
 pub const SHORT_LEN: usize = 2;
 pub const INT_LEN: usize = 4;

--- a/cdrs-tokio/Cargo.toml
+++ b/cdrs-tokio/Cargo.toml
@@ -50,3 +50,27 @@ lazy_static = "1.4.0"
 regex = "1.5.6"
 uuid = { version = "1.0.0", features = ["v4"] }
 time = { version = "0.3.9", features = ["std", "macros"] }
+
+[[example]]
+name = "crud_operations"
+required-features = ["derive"]
+
+[[example]]
+name = "generic_connection"
+required-features = ["derive"]
+
+[[example]]
+name = "insert_collection"
+required-features = ["derive"]
+
+[[example]]
+name = "multiple_thread"
+required-features = ["derive"]
+
+[[example]]
+name = "paged_query"
+required-features = ["derive"]
+
+[[example]]
+name = "prepare_batch_execute"
+required-features = ["derive"]

--- a/cdrs-tokio/examples/crud_operations.rs
+++ b/cdrs-tokio/examples/crud_operations.rs
@@ -1,19 +1,16 @@
 #[macro_use]
 extern crate maplit;
-
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use cdrs_tokio::authenticators::StaticPasswordAuthenticatorProvider;
 use cdrs_tokio::cluster::session::{Session, SessionBuilder, TcpSessionBuilder};
 use cdrs_tokio::cluster::{NodeTcpConfigBuilder, TcpConnectionManager};
+use cdrs_tokio::frame::TryFromRow;
 use cdrs_tokio::load_balancing::RoundRobinLoadBalancingStrategy;
 use cdrs_tokio::query::*;
 use cdrs_tokio::query_values;
-
-use cdrs_tokio::frame::TryFromRow;
 use cdrs_tokio::transport::TransportTcp;
 use cdrs_tokio::{IntoCdrsValue, TryFromRow, TryFromUdt};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 type CurrentSession = Session<
     TransportTcp,

--- a/cdrs-tokio/examples/generic_connection.rs
+++ b/cdrs-tokio/examples/generic_connection.rs
@@ -1,24 +1,3 @@
-use std::{
-    collections::HashMap,
-    net::IpAddr,
-    net::{Ipv4Addr, SocketAddr},
-    sync::Arc,
-};
-
-use cdrs_tokio::{
-    authenticators::{SaslAuthenticatorProvider, StaticPasswordAuthenticatorProvider},
-    cluster::session::Session,
-    cluster::{GenericClusterConfig, TcpConnectionManager},
-    error::Result,
-    load_balancing::RoundRobinLoadBalancingStrategy,
-    query::*,
-    query_values,
-    retry::DefaultRetryPolicy,
-    transport::TransportTcp,
-    types::prelude::*,
-    TryFromRow, TryFromUdt,
-};
-
 use cdrs_tokio::cluster::connection_pool::ConnectionPoolConfig;
 use cdrs_tokio::cluster::session::{
     NodeDistanceEvaluatorWrapper, ReconnectionPolicyWrapper, RetryPolicyWrapper,
@@ -32,8 +11,27 @@ use cdrs_tokio::future::BoxFuture;
 use cdrs_tokio::load_balancing::node_distance_evaluator::AllLocalNodeDistanceEvaluator;
 use cdrs_tokio::retry::{ConstantReconnectionPolicy, ReconnectionPolicy};
 use cdrs_tokio::IntoCdrsValue;
+use cdrs_tokio::{
+    authenticators::{SaslAuthenticatorProvider, StaticPasswordAuthenticatorProvider},
+    cluster::session::Session,
+    cluster::{GenericClusterConfig, TcpConnectionManager},
+    error::Result,
+    load_balancing::RoundRobinLoadBalancingStrategy,
+    query::*,
+    query_values,
+    retry::DefaultRetryPolicy,
+    transport::TransportTcp,
+    types::prelude::*,
+    TryFromRow, TryFromUdt,
+};
 use futures::FutureExt;
 use maplit::hashmap;
+use std::{
+    collections::HashMap,
+    net::IpAddr,
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 use tokio::sync::mpsc::Sender;
 
 type CurrentSession = Session<

--- a/cdrs-tokio/examples/insert_collection.rs
+++ b/cdrs-tokio/examples/insert_collection.rs
@@ -1,9 +1,5 @@
 #[macro_use]
 extern crate maplit;
-
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use cdrs_tokio::authenticators::StaticPasswordAuthenticatorProvider;
 use cdrs_tokio::cluster::session::{Session, SessionBuilder, TcpSessionBuilder};
 use cdrs_tokio::cluster::{NodeTcpConfigBuilder, TcpConnectionManager};
@@ -11,9 +7,10 @@ use cdrs_tokio::frame::TryFromRow;
 use cdrs_tokio::load_balancing::RoundRobinLoadBalancingStrategy;
 use cdrs_tokio::query::*;
 use cdrs_tokio::query_values;
-
 use cdrs_tokio::transport::TransportTcp;
 use cdrs_tokio::{IntoCdrsValue, TryFromRow, TryFromUdt};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 type CurrentSession = Session<
     TransportTcp,

--- a/cdrs-tokio/examples/multiple_thread.rs
+++ b/cdrs-tokio/examples/multiple_thread.rs
@@ -1,15 +1,13 @@
-use std::sync::Arc;
-
 use cdrs_tokio::authenticators::NoneAuthenticatorProvider;
 use cdrs_tokio::cluster::session::{Session, SessionBuilder, TcpSessionBuilder};
 use cdrs_tokio::cluster::{NodeTcpConfigBuilder, TcpConnectionManager};
-use cdrs_tokio::query::*;
-use cdrs_tokio::query_values;
-
 use cdrs_tokio::frame::TryFromRow;
 use cdrs_tokio::load_balancing::RoundRobinLoadBalancingStrategy;
+use cdrs_tokio::query::*;
+use cdrs_tokio::query_values;
 use cdrs_tokio::transport::TransportTcp;
 use cdrs_tokio::{IntoCdrsValue, TryFromRow, TryFromUdt};
+use std::sync::Arc;
 
 type CurrentSession = Session<
     TransportTcp,

--- a/cdrs-tokio/examples/paged_query.rs
+++ b/cdrs-tokio/examples/paged_query.rs
@@ -1,15 +1,13 @@
-use std::sync::Arc;
-
 use cdrs_tokio::authenticators::NoneAuthenticatorProvider;
 use cdrs_tokio::cluster::session::{Session, SessionBuilder, TcpSessionBuilder};
 use cdrs_tokio::cluster::{NodeTcpConfigBuilder, PagerState, TcpConnectionManager};
+use cdrs_tokio::frame::TryFromRow;
 use cdrs_tokio::load_balancing::RoundRobinLoadBalancingStrategy;
 use cdrs_tokio::query::*;
 use cdrs_tokio::query_values;
-
-use cdrs_tokio::frame::TryFromRow;
 use cdrs_tokio::transport::TransportTcp;
 use cdrs_tokio::{IntoCdrsValue, TryFromRow};
+use std::sync::Arc;
 
 type CurrentSession = Session<
     TransportTcp,

--- a/cdrs-tokio/examples/prepare_batch_execute.rs
+++ b/cdrs-tokio/examples/prepare_batch_execute.rs
@@ -1,14 +1,12 @@
-use std::sync::Arc;
-
 use cdrs_tokio::authenticators::NoneAuthenticatorProvider;
 use cdrs_tokio::cluster::session::{Session, SessionBuilder, TcpSessionBuilder};
 use cdrs_tokio::cluster::{NodeTcpConfigBuilder, TcpConnectionManager};
 use cdrs_tokio::load_balancing::RoundRobinLoadBalancingStrategy;
 use cdrs_tokio::query::*;
 use cdrs_tokio::query_values;
-
 use cdrs_tokio::transport::TransportTcp;
 use cdrs_tokio::{IntoCdrsValue, TryFromRow};
+use std::sync::Arc;
 
 type CurrentSession = Session<
     TransportTcp,

--- a/cdrs-tokio/tests/derive_traits.rs
+++ b/cdrs-tokio/tests/derive_traits.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "derive")]
 mod common;
 
 #[cfg(feature = "e2e-tests")]


### PR DESCRIPTION
The examples won't compile unless the `"derive"` feature is enabled and this means you can't run `cargo test` without getting errors. I updated the `Cargo.toml` to ensure that they are only included when the `"derive"` feature is enabled.

Also added a check to the CI that uses [cargo-hack](https://github.com/taiki-e/cargo-hack) to check that all targets compile with every combination of features.