### PR TITLE
Remove CInet

### DIFF
--- a/cassandra-protocol/src/frame/events.rs
+++ b/cassandra-protocol/src/frame/events.rs
@@ -6,6 +6,7 @@ use derive_more::Display;
 use std::cmp::PartialEq;
 use std::convert::TryFrom;
 use std::io::Cursor;
+use std::net::SocketAddr;
 
 // Event types
 const TOPOLOGY_CHANGE: &str = "TOPOLOGY_CHANGE";
@@ -149,21 +150,21 @@ impl FromCursor for ServerEvent {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TopologyChange {
     pub change_type: TopologyChangeType,
-    pub addr: CInet,
+    pub addr: SocketAddr,
 }
 
 impl Serialize for TopologyChange {
     //noinspection DuplicatedCode
     fn serialize(&self, cursor: &mut Cursor<&mut Vec<u8>>, version: Version) {
         self.change_type.serialize(cursor, version);
-        self.addr.serialize(cursor, version);
+        CInet { addr: self.addr }.serialize(cursor, version);
     }
 }
 
 impl FromCursor for TopologyChange {
     fn from_cursor(cursor: &mut Cursor<&[u8]>, version: Version) -> error::Result<TopologyChange> {
         let change_type = TopologyChangeType::from_cursor(cursor, version)?;
-        let addr = CInet::from_cursor(cursor, version)?;
+        let addr = CInet::from_cursor(cursor, version)?.addr;
 
         Ok(TopologyChange { change_type, addr })
     }
@@ -201,21 +202,21 @@ impl FromCursor for TopologyChangeType {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StatusChange {
     pub change_type: StatusChangeType,
-    pub addr: CInet,
+    pub addr: SocketAddr,
 }
 
 impl Serialize for StatusChange {
     //noinspection DuplicatedCode
     fn serialize(&self, cursor: &mut Cursor<&mut Vec<u8>>, version: Version) {
         self.change_type.serialize(cursor, version);
-        self.addr.serialize(cursor, version);
+        CInet { addr: self.addr }.serialize(cursor, version);
     }
 }
 
 impl FromCursor for StatusChange {
     fn from_cursor(cursor: &mut Cursor<&[u8]>, version: Version) -> error::Result<StatusChange> {
         let change_type = StatusChangeType::from_cursor(cursor, version)?;
-        let addr = CInet::from_cursor(cursor, version)?;
+        let addr = CInet::from_cursor(cursor, version)?.addr;
 
         Ok(StatusChange { change_type, addr })
     }
@@ -731,7 +732,7 @@ mod server_event {
 
         let expected = ServerEvent::TopologyChange(TopologyChange {
             change_type: TopologyChangeType::NewNode,
-            addr: CInet::new("127.0.0.1:1".parse().unwrap()),
+            addr: "127.0.0.1:1".parse().unwrap(),
         });
 
         test_encode_decode(bytes, expected);
@@ -749,7 +750,7 @@ mod server_event {
 
         let expected = ServerEvent::TopologyChange(TopologyChange {
             change_type: TopologyChangeType::RemovedNode,
-            addr: CInet::new("127.0.0.1:1".parse().unwrap()),
+            addr: "127.0.0.1:1".parse().unwrap(),
         });
 
         test_encode_decode(bytes, expected);
@@ -766,7 +767,7 @@ mod server_event {
 
         let expected = ServerEvent::StatusChange(StatusChange {
             change_type: StatusChangeType::Up,
-            addr: CInet::new("127.0.0.1:1".parse().unwrap()),
+            addr: "127.0.0.1:1".parse().unwrap(),
         });
 
         test_encode_decode(bytes, expected);
@@ -783,7 +784,7 @@ mod server_event {
 
         let expected = ServerEvent::StatusChange(StatusChange {
             change_type: StatusChangeType::Down,
-            addr: CInet::new("127.0.0.1:1".parse().unwrap()),
+            addr: "127.0.0.1:1".parse().unwrap(),
         });
 
         test_encode_decode(bytes, expected);

--- a/cassandra-protocol/src/frame/events.rs
+++ b/cassandra-protocol/src/frame/events.rs
@@ -1,6 +1,6 @@
 use crate::frame::traits::FromCursor;
 use crate::frame::{Serialize, Version};
-use crate::types::{from_cursor_str, from_cursor_string_list, serialize_str, CInet, CIntShort};
+use crate::types::{from_cursor_str, from_cursor_string_list, serialize_str, CIntShort};
 use crate::{error, Error};
 use derive_more::Display;
 use std::cmp::PartialEq;
@@ -157,14 +157,14 @@ impl Serialize for TopologyChange {
     //noinspection DuplicatedCode
     fn serialize(&self, cursor: &mut Cursor<&mut Vec<u8>>, version: Version) {
         self.change_type.serialize(cursor, version);
-        CInet { addr: self.addr }.serialize(cursor, version);
+        self.addr.serialize(cursor, version);
     }
 }
 
 impl FromCursor for TopologyChange {
     fn from_cursor(cursor: &mut Cursor<&[u8]>, version: Version) -> error::Result<TopologyChange> {
         let change_type = TopologyChangeType::from_cursor(cursor, version)?;
-        let addr = CInet::from_cursor(cursor, version)?.addr;
+        let addr = SocketAddr::from_cursor(cursor, version)?;
 
         Ok(TopologyChange { change_type, addr })
     }
@@ -209,14 +209,14 @@ impl Serialize for StatusChange {
     //noinspection DuplicatedCode
     fn serialize(&self, cursor: &mut Cursor<&mut Vec<u8>>, version: Version) {
         self.change_type.serialize(cursor, version);
-        CInet { addr: self.addr }.serialize(cursor, version);
+        self.addr.serialize(cursor, version);
     }
 }
 
 impl FromCursor for StatusChange {
     fn from_cursor(cursor: &mut Cursor<&[u8]>, version: Version) -> error::Result<StatusChange> {
         let change_type = StatusChangeType::from_cursor(cursor, version)?;
-        let addr = CInet::from_cursor(cursor, version)?.addr;
+        let addr = SocketAddr::from_cursor(cursor, version)?;
 
         Ok(StatusChange { change_type, addr })
     }

--- a/cassandra-protocol/src/frame/message_error.rs
+++ b/cassandra-protocol/src/frame/message_error.rs
@@ -9,6 +9,7 @@ use crate::{error, Error};
 use derive_more::Display;
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
+use std::net::SocketAddr;
 
 /// CDRS error which could be returned by Cassandra server as a response. As in the specification,
 /// it contains an error code and an error message. Apart of those depending of type of error,
@@ -53,7 +54,7 @@ pub enum FailureInfo {
     /// Represents the number of nodes that experience a failure while executing the request.
     NumFailures(CInt),
     /// Error code map for affected nodes.
-    ReasonMap(HashMap<CInet, CIntShort>),
+    ReasonMap(HashMap<SocketAddr, CIntShort>),
 }
 
 impl Serialize for FailureInfo {
@@ -82,7 +83,7 @@ impl FromCursor for FailureInfo {
                 let mut map = HashMap::with_capacity(num_failures as usize);
 
                 for _ in 0..num_failures {
-                    let endpoint = CInet::from_cursor(cursor, version)?;
+                    let endpoint = SocketAddr::from_cursor(cursor, version)?;
                     let error_code = CIntShort::from_cursor(cursor, version)?;
                     map.insert(endpoint, error_code);
                 }

--- a/cassandra-protocol/src/frame/message_event.rs
+++ b/cassandra-protocol/src/frame/message_event.rs
@@ -27,7 +27,6 @@ mod tests {
     use super::*;
     use crate::frame::events::*;
     use crate::frame::traits::FromCursor;
-    use crate::types::CInet;
     use std::io::Cursor;
 
     #[test]
@@ -40,7 +39,7 @@ mod tests {
         ];
         let expected = ServerEvent::TopologyChange(TopologyChange {
             change_type: TopologyChangeType::NewNode,
-            addr: CInet::new("127.0.0.1:1".parse().unwrap()),
+            addr: "127.0.0.1:1".parse().unwrap(),
         });
 
         {

--- a/cdrs-tokio/src/cluster/cluster_metadata_manager.rs
+++ b/cdrs-tokio/src/cluster/cluster_metadata_manager.rs
@@ -390,25 +390,25 @@ impl<T: CdrsTransport + 'static, CM: ConnectionManager<T> + 'static> ClusterMeta
         let metadata = self.metadata.load().clone();
         match event.change_type {
             TopologyChangeType::NewNode => {
-                if metadata.has_node_by_rpc_address(event.addr.addr) {
+                if metadata.has_node_by_rpc_address(event.addr) {
                     debug!(
-                        broadcast_rpc_address = %event.addr.addr,
+                        broadcast_rpc_address = %event.addr,
                         "Trying to add already existing node - ignoring."
                     );
                 } else {
-                    self.add_new_node(event.addr.addr, NodeState::Unknown, metadata)
+                    self.add_new_node(event.addr, NodeState::Unknown, metadata)
                         .await;
                 }
             }
             TopologyChangeType::RemovedNode => {
-                if metadata.has_node_by_rpc_address(event.addr.addr) {
-                    debug!(broadcast_rpc_address = %event.addr.addr, "Removing node from cluster.");
+                if metadata.has_node_by_rpc_address(event.addr) {
+                    debug!(broadcast_rpc_address = %event.addr, "Removing node from cluster.");
 
                     self.metadata
-                        .store(Arc::new(metadata.clone_without_node(event.addr.addr)));
+                        .store(Arc::new(metadata.clone_without_node(event.addr)));
                 } else {
                     debug!(
-                        broadcast_rpc_address = %event.addr.addr,
+                        broadcast_rpc_address = %event.addr,
                         "Trying to remove a node outside the cluster."
                     );
                 }
@@ -418,7 +418,7 @@ impl<T: CdrsTransport + 'static, CM: ConnectionManager<T> + 'static> ClusterMeta
 
     async fn process_status_event(&self, event: StatusChange) {
         let metadata = self.metadata.load().clone();
-        let node = metadata.find_node_by_rpc_address(event.addr.addr);
+        let node = metadata.find_node_by_rpc_address(event.addr);
         match event.change_type {
             StatusChangeType::Up => {
                 if let Some(node) = node {
@@ -433,8 +433,7 @@ impl<T: CdrsTransport + 'static, CM: ConnectionManager<T> + 'static> ClusterMeta
                         debug!(?node, "Ignoring up node event for already up node.");
                     }
                 } else {
-                    self.add_new_node(event.addr.addr, NodeState::Up, metadata)
-                        .await;
+                    self.add_new_node(event.addr, NodeState::Up, metadata).await;
                 }
             }
             StatusChangeType::Down => {
@@ -450,7 +449,7 @@ impl<T: CdrsTransport + 'static, CM: ConnectionManager<T> + 'static> ClusterMeta
                         debug!(?node, "Ignoring down node event for already downed node.");
                     }
                 } else {
-                    debug!(broadcast_rpc_address = %event.addr.addr, "Unknown node down.");
+                    debug!(broadcast_rpc_address = %event.addr, "Unknown node down.");
                 }
             }
         }


### PR DESCRIPTION
Make the public API easier to use as the user does not need to know about the CInet implementation detail