### PR TITLE
clone for BodyResReady

### DIFF
--- a/cassandra-protocol/src/frame/message_ready.rs
+++ b/cassandra-protocol/src/frame/message_ready.rs
@@ -2,7 +2,7 @@ use crate::error;
 use crate::frame::{FromCursor, Serialize, Version};
 use std::io::Cursor;
 
-#[derive(Debug, PartialEq, Default, Ord, PartialOrd, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Default, Ord, PartialOrd, Eq, Hash)]
 pub struct BodyResReady;
 
 impl Serialize for BodyResReady {


### PR DESCRIPTION
So it can be used in enums with the other message body structs.