### PR TITLE
Make invalid states unrepresentable in ErrorBody

### DIFF
--- a/cassandra-protocol/src/error.rs
+++ b/cassandra-protocol/src/error.rs
@@ -63,8 +63,8 @@ pub enum Error {
     #[error("Unexpected schema change target: {0}")]
     UnexpectedSchemaChangeTarget(String),
     /// Unexpected additional error info.
-    #[error("Unexpected additional error info: {0}")]
-    UnexpectedAdditionalErrorInfo(CInt),
+    #[error("Unexpected error code: {0}")]
+    UnexpectedErrorCode(CInt),
     /// Unexpected write type.
     #[error("Unexpected write type: {0}")]
     UnexpectedWriteType(String),
@@ -141,9 +141,7 @@ impl Clone for Error {
             Error::UnexpectedSchemaChangeTarget(value) => {
                 Error::UnexpectedSchemaChangeTarget(value.clone())
             }
-            Error::UnexpectedAdditionalErrorInfo(value) => {
-                Error::UnexpectedAdditionalErrorInfo(*value)
-            }
+            Error::UnexpectedErrorCode(value) => Error::UnexpectedErrorCode(*value),
             Error::UnexpectedWriteType(value) => Error::UnexpectedWriteType(value.clone()),
             Error::NonRequestOpcode(value) => Error::NonRequestOpcode(*value),
             Error::NonResponseOpcode(value) => Error::NonResponseOpcode(*value),

--- a/cassandra-protocol/src/frame/message_error.rs
+++ b/cassandra-protocol/src/frame/message_error.rs
@@ -91,6 +91,7 @@ impl FromCursor for FailureInfo {
 /// [Cassandra protocol v4]
 /// (<https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec>).
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum ErrorType {
     Server,
     Protocol,

--- a/cdrs-tokio/src/cluster/cluster_metadata_manager.rs
+++ b/cdrs-tokio/src/cluster/cluster_metadata_manager.rs
@@ -5,7 +5,7 @@ use cassandra_protocol::frame::events::{
     SchemaChangeOptions, SchemaChangeType, StatusChange, StatusChangeType, TopologyChange,
     TopologyChangeType,
 };
-use cassandra_protocol::frame::message_error::{AdditionalErrorInfo, ErrorBody};
+use cassandra_protocol::frame::message_error::{ErrorBody, ErrorType};
 use cassandra_protocol::frame::{Envelope, Flags, Version};
 use cassandra_protocol::query::{Query, QueryParams, QueryParamsBuilder, QueryValues};
 use cassandra_protocol::token::Murmur3Token;
@@ -707,7 +707,7 @@ impl<T: CdrsTransport + 'static, CM: ConnectionManager<T> + 'static> ClusterMeta
             Err(Error::Server {
                 body:
                     ErrorBody {
-                        additional_info: AdditionalErrorInfo::Invalid,
+                        ty: ErrorType::Invalid,
                         ..
                     },
                 ..

--- a/cdrs-tokio/src/cluster/session.rs
+++ b/cdrs-tokio/src/cluster/session.rs
@@ -3,6 +3,7 @@ use cassandra_protocol::compression::Compression;
 use cassandra_protocol::consistency::Consistency;
 use cassandra_protocol::error;
 use cassandra_protocol::events::ServerEvent;
+use cassandra_protocol::frame::message_error::ErrorType;
 use cassandra_protocol::frame::message_response::ResponseBody;
 use cassandra_protocol::frame::message_result::{BodyResResultPrepared, TableSpec};
 use cassandra_protocol::frame::{Envelope, Flags, Serialize, Version};
@@ -274,7 +275,7 @@ impl<
 
         if let Err(error::Error::Server { body: error, addr }) = &result {
             // if query is unprepared
-            if error.error_code == 0x2500 {
+            if let ErrorType::Unprepared(_) = error.ty {
                 debug!("Re-preparing statement.");
 
                 // We need to send the prepare statement to the failing node.

--- a/cdrs-tokio/src/retry/retry_policy.rs
+++ b/cdrs-tokio/src/retry/retry_policy.rs
@@ -2,7 +2,7 @@ use derive_more::Display;
 
 use cassandra_protocol::error::Error;
 use cassandra_protocol::frame::message_error::{
-    AdditionalErrorInfo, ErrorBody, ReadTimeoutError, WriteTimeoutError, WriteType,
+    ErrorBody, ErrorType, ReadTimeoutError, WriteTimeoutError, WriteType,
 };
 
 #[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Copy, Clone, Display)]
@@ -75,7 +75,7 @@ impl RetrySession for DefaultRetrySession {
             | Error::Server {
                 body:
                     ErrorBody {
-                        additional_info: AdditionalErrorInfo::Overloaded,
+                        ty: ErrorType::Overloaded,
                         ..
                     },
                 ..
@@ -83,7 +83,7 @@ impl RetrySession for DefaultRetrySession {
             | Error::Server {
                 body:
                     ErrorBody {
-                        additional_info: AdditionalErrorInfo::Server,
+                        ty: ErrorType::Server,
                         ..
                     },
                 ..
@@ -91,7 +91,7 @@ impl RetrySession for DefaultRetrySession {
             | Error::Server {
                 body:
                     ErrorBody {
-                        additional_info: AdditionalErrorInfo::Truncate,
+                        ty: ErrorType::Truncate,
                         ..
                     },
                 ..
@@ -105,7 +105,7 @@ impl RetrySession for DefaultRetrySession {
             Error::Server {
                 body:
                     ErrorBody {
-                        additional_info: AdditionalErrorInfo::Unavailable(_),
+                        ty: ErrorType::Unavailable(_),
                         ..
                     },
                 ..
@@ -120,8 +120,7 @@ impl RetrySession for DefaultRetrySession {
             Error::Server {
                 body:
                     ErrorBody {
-                        additional_info:
-                            AdditionalErrorInfo::ReadTimeout(error @ ReadTimeoutError { .. }),
+                        ty: ErrorType::ReadTimeout(error @ ReadTimeoutError { .. }),
                         ..
                     },
                 ..
@@ -139,8 +138,7 @@ impl RetrySession for DefaultRetrySession {
             Error::Server {
                 body:
                     ErrorBody {
-                        additional_info:
-                            AdditionalErrorInfo::WriteTimeout(error @ WriteTimeoutError { .. }),
+                        ty: ErrorType::WriteTimeout(error @ WriteTimeoutError { .. }),
                         ..
                     },
                 ..
@@ -158,7 +156,7 @@ impl RetrySession for DefaultRetrySession {
             Error::Server {
                 body:
                     ErrorBody {
-                        additional_info: AdditionalErrorInfo::IsBootstrapping,
+                        ty: ErrorType::IsBootstrapping,
                         ..
                     },
                 ..


### PR DESCRIPTION
error_code can just be derived from the AdditionalErrorInfo at encode time.