### PR TITLE
Replace query::Query with BodyReqQuery

### DIFF
--- a/cassandra-protocol/src/frame/message_query.rs
+++ b/cassandra-protocol/src/frame/message_query.rs
@@ -2,7 +2,7 @@ use crate::consistency::Consistency;
 use crate::error;
 use crate::frame::traits::FromCursor;
 use crate::frame::{Direction, Envelope, Flags, Opcode, Serialize, Version};
-use crate::query::{Query, QueryParams, QueryValues};
+use crate::query::{QueryParams, QueryValues};
 use crate::types::{from_cursor_str_long, serialize_str_long, CBytes, CInt, CLong, INT_LEN};
 use std::io::Cursor;
 
@@ -118,18 +118,18 @@ impl Envelope {
     }
 
     #[inline]
-    pub fn new_query(query: Query, flags: Flags, version: Version) -> Envelope {
+    pub fn new_query(query: BodyReqQuery, flags: Flags, version: Version) -> Envelope {
         Envelope::new_req_query(
             query.query,
-            query.params.consistency,
-            query.params.values,
-            query.params.with_names,
-            query.params.page_size,
-            query.params.paging_state,
-            query.params.serial_consistency,
-            query.params.timestamp,
-            query.params.keyspace,
-            query.params.now_in_seconds,
+            query.query_params.consistency,
+            query.query_params.values,
+            query.query_params.with_names,
+            query.query_params.page_size,
+            query.query_params.paging_state,
+            query.query_params.serial_consistency,
+            query.query_params.timestamp,
+            query.query_params.keyspace,
+            query.query_params.now_in_seconds,
             flags,
             version,
         )

--- a/cassandra-protocol/src/query.rs
+++ b/cassandra-protocol/src/query.rs
@@ -14,11 +14,3 @@ pub use crate::query::query_flags::QueryFlags;
 pub use crate::query::query_params::QueryParams;
 pub use crate::query::query_params_builder::QueryParamsBuilder;
 pub use crate::query::query_values::QueryValues;
-
-/// Structure that represents CQL query and parameters which will be applied during
-/// its execution
-#[derive(Debug, Default)]
-pub struct Query {
-    pub query: String,
-    pub params: QueryParams,
-}

--- a/cdrs-tokio/src/cluster/cluster_metadata_manager.rs
+++ b/cdrs-tokio/src/cluster/cluster_metadata_manager.rs
@@ -6,8 +6,9 @@ use cassandra_protocol::frame::events::{
     TopologyChangeType,
 };
 use cassandra_protocol::frame::message_error::{ErrorBody, ErrorType};
+use cassandra_protocol::frame::message_query::BodyReqQuery;
 use cassandra_protocol::frame::{Envelope, Flags, Version};
-use cassandra_protocol::query::{Query, QueryParams, QueryParamsBuilder, QueryValues};
+use cassandra_protocol::query::{QueryParams, QueryParamsBuilder, QueryValues};
 use cassandra_protocol::token::Murmur3Token;
 use cassandra_protocol::types::list::List;
 use cassandra_protocol::types::rows::Row;
@@ -78,9 +79,9 @@ async fn send_query_with_params<T: CdrsTransport>(
     version: Version,
     beta_protocol: bool,
 ) -> Result<Option<Vec<Row>>> {
-    let query = Query {
+    let query = BodyReqQuery {
         query: query.to_string(),
-        params: query_params,
+        query_params,
     };
 
     let flags = if beta_protocol {

--- a/cdrs-tokio/src/cluster/session.rs
+++ b/cdrs-tokio/src/cluster/session.rs
@@ -4,10 +4,11 @@ use cassandra_protocol::consistency::Consistency;
 use cassandra_protocol::error;
 use cassandra_protocol::events::ServerEvent;
 use cassandra_protocol::frame::message_error::ErrorType;
+use cassandra_protocol::frame::message_query::BodyReqQuery;
 use cassandra_protocol::frame::message_response::ResponseBody;
 use cassandra_protocol::frame::message_result::{BodyResResultPrepared, TableSpec};
 use cassandra_protocol::frame::{Envelope, Flags, Serialize, Version};
-use cassandra_protocol::query::{PreparedQuery, Query, QueryBatch, QueryValues};
+use cassandra_protocol::query::{PreparedQuery, QueryBatch, QueryValues};
 use cassandra_protocol::token::Murmur3Token;
 use cassandra_protocol::types::value::Value;
 use cassandra_protocol::types::{CIntShort, SHORT_LEN};
@@ -527,9 +528,9 @@ impl<
             .as_ref()
             .map(|values| serialize_routing_key(values, self.version));
 
-        let query = Query {
+        let query = BodyReqQuery {
             query: query.to_string(),
-            params: parameters.query_params,
+            query_params: parameters.query_params,
         };
 
         let flags = prepare_flags(


### PR DESCRIPTION
BodyReqQuery and Query have the exact same definition.
So I kept BodyReqQuery which is consistent with other such types and replaced all usages of Query with BodyReqQuery