### PR TITLE
don't include value length in serialised routing key

### DIFF
--- a/cdrs-tokio/src/cluster/session.rs
+++ b/cdrs-tokio/src/cluster/session.rs
@@ -132,7 +132,10 @@ fn serialize_routing_key_with_indexes(
         0 => None,
         1 => values
             .get(pk_indexes[0] as usize)
-            .map(|value| value.serialize_to_vec(version)),
+            .and_then(|value| match value {
+                Value::Some(value) => Some(value.serialize_to_vec(version)),
+                _ => None,
+            }),
         _ => {
             let mut buf = vec![];
             if pk_indexes


### PR DESCRIPTION
The length of the value should not be encoded in the routing key if it's a single partition key. 

The serialisation rules for composite partition keys include the length so that can remain. 

Notes:
https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/db/marshal/CompositeType.java