### PR TITLE
Remove ColType::Null

### DIFF
--- a/cassandra-protocol/src/frame/message_result.rs
+++ b/cassandra-protocol/src/frame/message_result.rs
@@ -529,7 +529,6 @@ pub enum ColType {
     Set,
     Udt,
     Tuple,
-    Null,
 }
 
 impl TryFrom<CIntShort> for ColType {
@@ -607,7 +606,6 @@ impl Serialize for ColType {
             ColType::Set => 0x0022,
             ColType::Udt => 0x0030,
             ColType::Tuple => 0x0031,
-            _ => 0x6666,
         } as CIntShort)
             .serialize(cursor, version);
     }

--- a/cassandra-protocol/src/types/cassandra_type.rs
+++ b/cassandra-protocol/src/types/cassandra_type.rs
@@ -69,7 +69,6 @@ pub fn wrapper_fn(
         ColType::Set => &wrappers::set,
         ColType::Udt => &wrappers::udt,
         ColType::Tuple => &wrappers::tuple,
-        ColType::Null => &wrappers::null,
     }
 }
 


### PR DESCRIPTION
`ColType` is used to represent the type a field has.
A field cannot have a null type so I have removed the `Null` variant from `ColType`.

This is not to be confused with `CassandraType` where the `Null` variant is possible because it represents the returned results of a field which may be of the fields type or may be null.