### PR TITLE
CBytes properly distinguish between null and empty as per spec

### DIFF
--- a/cassandra-protocol/src/types.rs
+++ b/cassandra-protocol/src/types.rs
@@ -283,9 +283,9 @@ impl CBytes {
         CBytes { bytes: Some(bytes) }
     }
 
-    /// Creates Cassandra bytes that represent empty or null value
+    /// Creates Cassandra bytes that represent null value
     #[inline]
-    pub fn new_empty() -> CBytes {
+    pub fn new_null() -> CBytes {
         CBytes { bytes: None }
     }
 
@@ -301,7 +301,7 @@ impl CBytes {
     }
 
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub fn is_null_or_empty(&self) -> bool {
         match &self.bytes {
             None => true,
             Some(bytes) => bytes.is_empty(),

--- a/cassandra-protocol/src/types/data_serialization_types.rs
+++ b/cassandra-protocol/src/types/data_serialization_types.rs
@@ -234,7 +234,7 @@ pub fn decode_udt(bytes: &[u8], l: usize, version: Version) -> Result<Vec<CBytes
             .or_else(|err| match err {
                 error::Error::Io(io_err) => {
                     if io_err.kind() == io::ErrorKind::UnexpectedEof {
-                        Ok(CBytes::new_empty())
+                        Ok(CBytes::new_null())
                     } else {
                         Err(io_err.into())
                     }

--- a/cassandra-protocol/src/types/rows.rs
+++ b/cassandra-protocol/src/types/rows.rs
@@ -54,7 +54,7 @@ impl Row {
     pub fn is_empty(&self, index: usize) -> bool {
         self.row_content
             .get(index)
-            .map(|data| data.is_empty())
+            .map(|data| data.is_null_or_empty())
             .unwrap_or(false)
     }
 

--- a/cdrs-tokio/examples/paged_query.rs
+++ b/cdrs-tokio/examples/paged_query.rs
@@ -196,11 +196,19 @@ async fn paged_with_values_list(session: &CurrentSession) {
     println!("Testing values 100 and 101");
     assert_amount_query_pager!(2);
     assert!(query_pager.has_more());
-    assert!(!query_pager.pager_state().cursor().unwrap().is_empty());
+    assert!(!query_pager
+        .pager_state()
+        .cursor()
+        .unwrap()
+        .is_null_or_empty());
     println!("Testing values 102 and 103");
     assert_amount_query_pager!(2);
     assert!(query_pager.has_more());
-    assert!(!query_pager.pager_state().cursor().unwrap().is_empty());
+    assert!(!query_pager
+        .pager_state()
+        .cursor()
+        .unwrap()
+        .is_null_or_empty());
     println!("Testing value 104");
     assert_amount_query_pager!(1);
     // Now no more rows should be queried


### PR DESCRIPTION
The current method names of CBytes confuses the null and empty states.
The spec explains they are two separate states: https://github.com/apache/cassandra/blob/ee8b66da8ce3bdac0378f89159d8bd7e45a91363/doc/native_protocol_v5.spec#L1063