### PR TITLE
Murmur3 fix

### DIFF
--- a/cassandra-protocol/Cargo.toml
+++ b/cassandra-protocol/Cargo.toml
@@ -30,3 +30,4 @@ snap = "1.0.5"
 thiserror = "1.0.31"
 time = { version = "0.3.9", features = ["std", "macros"] }
 uuid = "1.0.0"
+bytes = "1.1.0"


### PR DESCRIPTION
The position was not being updated properly and the loop while condition was incorrect. Using the bytes library means the bytes can be removed from the partition key as it loops.