### PR TITLE
Session::build is async and waits on task init

### DIFF
--- a/cdrs-tokio/Cargo.toml
+++ b/cdrs-tokio/Cargo.toml
@@ -36,6 +36,7 @@ tokio-rustls = { version = "0.23.4", optional = true }
 tracing = "0.1.35"
 uuid = "1.0.0"
 webpki = { version = "0.22.0", optional = true }
+async-trait = "0.1.59"
 
 [dependencies.rustls]
 version = "0.20.6"

--- a/cdrs-tokio/Cargo.toml
+++ b/cdrs-tokio/Cargo.toml
@@ -36,7 +36,6 @@ tokio-rustls = { version = "0.23.4", optional = true }
 tracing = "0.1.35"
 uuid = "1.0.0"
 webpki = { version = "0.22.0", optional = true }
-async-trait = "0.1.59"
 
 [dependencies.rustls]
 version = "0.20.6"

--- a/cdrs-tokio/examples/crud_operations.rs
+++ b/cdrs-tokio/examples/crud_operations.rs
@@ -32,6 +32,7 @@ async fn main() {
     let mut session: CurrentSession =
         TcpSessionBuilder::new(RoundRobinLoadBalancingStrategy::new(), config)
             .build()
+            .await
             .unwrap();
 
     create_keyspace(&mut session).await;

--- a/cdrs-tokio/examples/insert_collection.rs
+++ b/cdrs-tokio/examples/insert_collection.rs
@@ -32,6 +32,7 @@ async fn main() {
     let mut session: CurrentSession =
         TcpSessionBuilder::new(RoundRobinLoadBalancingStrategy::new(), cluster_config)
             .build()
+            .await
             .unwrap();
 
     create_keyspace(&mut session).await;

--- a/cdrs-tokio/examples/multiple_thread.rs
+++ b/cdrs-tokio/examples/multiple_thread.rs
@@ -24,8 +24,12 @@ async fn main() {
         .await
         .unwrap();
     let lb = RoundRobinLoadBalancingStrategy::new();
-    let session: Arc<CurrentSession> =
-        Arc::new(TcpSessionBuilder::new(lb, cluster_config).build().unwrap());
+    let session: Arc<CurrentSession> = Arc::new(
+        TcpSessionBuilder::new(lb, cluster_config)
+            .build()
+            .await
+            .unwrap(),
+    );
 
     create_keyspace(session.clone()).await;
     create_table(session.clone()).await;

--- a/cdrs-tokio/examples/paged_query.rs
+++ b/cdrs-tokio/examples/paged_query.rs
@@ -50,7 +50,10 @@ async fn main() {
         .await
         .unwrap();
     let lb = RoundRobinLoadBalancingStrategy::new();
-    let session = TcpSessionBuilder::new(lb, cluster_config).build().unwrap();
+    let session = TcpSessionBuilder::new(lb, cluster_config)
+        .build()
+        .await
+        .unwrap();
 
     create_keyspace(&session).await;
     create_udt(&session).await;

--- a/cdrs-tokio/examples/prepare_batch_execute.rs
+++ b/cdrs-tokio/examples/prepare_batch_execute.rs
@@ -36,7 +36,10 @@ async fn main() {
         .await
         .unwrap();
     let lb = RoundRobinLoadBalancingStrategy::new();
-    let mut session = TcpSessionBuilder::new(lb, cluster_config).build().unwrap();
+    let mut session = TcpSessionBuilder::new(lb, cluster_config)
+        .build()
+        .await
+        .unwrap();
 
     create_keyspace(&mut session).await;
     create_table(&mut session).await;

--- a/cdrs-tokio/src/lib.rs
+++ b/cdrs-tokio/src/lib.rs
@@ -19,6 +19,7 @@
 //!         .unwrap();
 //!     let session = TcpSessionBuilder::new(RoundRobinLoadBalancingStrategy::new(), cluster_config)
 //!         .build()
+//!         .await
 //!         .unwrap();
 //!
 //!     let create_ks = "CREATE KEYSPACE IF NOT EXISTS test_ks WITH REPLICATION = { \

--- a/cdrs-tokio/tests/common.rs
+++ b/cdrs-tokio/tests/common.rs
@@ -52,6 +52,7 @@ pub async fn setup_multiple(
     let session = TcpSessionBuilder::new(RoundRobinLoadBalancingStrategy::new(), cluster_config)
         .with_reconnection_policy(Arc::new(NeverReconnectionPolicy::default()))
         .build()
+        .await
         .unwrap();
     let re_table_name = Regex::new(r"CREATE TABLE IF NOT EXISTS (\w+\.\w+)").unwrap();
 

--- a/cdrs-tokio/tests/compression.rs
+++ b/cdrs-tokio/tests/compression.rs
@@ -38,6 +38,7 @@ async fn encode_decode_test(version: Version) {
         .with_reconnection_policy(Arc::new(NeverReconnectionPolicy::default()))
         .with_compression(Compression::Lz4)
         .build()
+        .await
         .unwrap();
 
     session

--- a/cdrs-tokio/tests/keyspace.rs
+++ b/cdrs-tokio/tests/keyspace.rs
@@ -34,6 +34,7 @@ async fn create_keyspace() {
     let session = TcpSessionBuilder::new(lb, cluster_config)
         .with_reconnection_policy(Arc::new(NeverReconnectionPolicy::default()))
         .build()
+        .await
         .unwrap();
 
     let drop_query = "DROP KEYSPACE IF EXISTS create_ks_test";
@@ -107,6 +108,7 @@ async fn alter_keyspace() {
     let session = TcpSessionBuilder::new(lb, cluster_config)
         .with_reconnection_policy(Arc::new(NeverReconnectionPolicy::default()))
         .build()
+        .await
         .unwrap();
 
     let drop_query = "DROP KEYSPACE IF EXISTS alter_ks_test";
@@ -171,6 +173,7 @@ async fn use_keyspace() {
     let session = TcpSessionBuilder::new(lb, cluster_config)
         .with_reconnection_policy(Arc::new(NeverReconnectionPolicy::default()))
         .build()
+        .await
         .unwrap();
 
     let create_query = "CREATE KEYSPACE IF NOT EXISTS use_ks_test WITH \
@@ -208,6 +211,7 @@ async fn drop_keyspace() {
     let session = TcpSessionBuilder::new(lb, cluster_config)
         .with_reconnection_policy(Arc::new(NeverReconnectionPolicy::default()))
         .build()
+        .await
         .unwrap();
 
     let create_query = "CREATE KEYSPACE IF NOT EXISTS drop_ks_test WITH \

--- a/cdrs-tokio/tests/multi_node_speculative_execution.rs
+++ b/cdrs-tokio/tests/multi_node_speculative_execution.rs
@@ -40,6 +40,7 @@ async fn multi_node_speculative_execution() {
             Duration::from_secs(0),
         )))
         .build()
+        .await
         .unwrap();
 
     let create_keyspace_query = "CREATE KEYSPACE IF NOT EXISTS cdrs_test WITH \

--- a/cdrs-tokio/tests/multithread.rs
+++ b/cdrs-tokio/tests/multithread.rs
@@ -24,6 +24,7 @@ async fn multithread() {
         TcpSessionBuilder::new(RoundRobinLoadBalancingStrategy::new(), cluster_config)
             .with_reconnection_policy(Arc::new(NeverReconnectionPolicy::default()))
             .build()
+            .await
             .unwrap();
 
     no_compression.query("CREATE KEYSPACE IF NOT EXISTS test_ks WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };").await.expect("Could not create ks");

--- a/cdrs-tokio/tests/paged_query.rs
+++ b/cdrs-tokio/tests/paged_query.rs
@@ -24,6 +24,7 @@ async fn paged_query() {
     let session = TcpSessionBuilder::new(lb, cluster_config)
         .with_reconnection_policy(Arc::new(NeverReconnectionPolicy::default()))
         .build()
+        .await
         .unwrap();
 
     session

--- a/cdrs-tokio/tests/single_node_speculative_execution.rs
+++ b/cdrs-tokio/tests/single_node_speculative_execution.rs
@@ -38,6 +38,7 @@ async fn single_node_speculative_execution() {
             Duration::from_secs(1),
         )))
         .build()
+        .await
         .unwrap();
 
     let create_keyspace_query = "CREATE KEYSPACE IF NOT EXISTS cdrs_test WITH \

--- a/cdrs-tokio/tests/topology_aware.rs
+++ b/cdrs-tokio/tests/topology_aware.rs
@@ -43,6 +43,7 @@ async fn query_topology_aware() {
         "datacenter1".into(),
     )))
     .build()
+    .await
     .unwrap();
 
     let create_keyspace_query = "CREATE KEYSPACE IF NOT EXISTS cdrs_test WITH \


### PR DESCRIPTION
closes https://github.com/krojew/cdrs-tokio/issues/135

The Session::build method is now async.
The build method will not return until the control connection has completed its setup.
I believe this solves both of the issues noted in https://github.com/krojew/cdrs-tokio/issues/135

I had to change this:
```rust
impl<
        T: CdrsTransport,
        CM: ConnectionManager<T>,
        LB: LoadBalancingStrategy<T, CM> + Send + Sync + 'static,
    > SessionConfig<T, CM, LB>
```
to this: (note the added `'static`)
```rust
impl<
        T: CdrsTransport + 'static,
        CM: ConnectionManager<T> + 'static,
        LB: LoadBalancingStrategy<T, CM> + Send + Sync + 'static,
    > SessionConfig<T, CM, LB>
```

Not sure if this will have any affect on usability or not, my projects use of cdrs-tokio still compiles fine.