### PR TITLE
Set node to unknown state if timeout

### DIFF
--- a/cdrs-tokio/src/cluster/send_envelope.rs
+++ b/cdrs-tokio/src/cluster/send_envelope.rs
@@ -36,7 +36,7 @@ pub async fn send_envelope<T: CdrsTransport + 'static, CM: ConnectionManager<T> 
                     }
                 },
                 Err(error) => {
-                    eprintln!("Trasport error: {:?}; for node {:?}", error,node);
+                    eprintln!("Trasport error: {:?}; for node {:?}", error, node);
                     node.set_state_to_unknown();
                     continue 'next_node;
                 }

--- a/cdrs-tokio/src/cluster/send_envelope.rs
+++ b/cdrs-tokio/src/cluster/send_envelope.rs
@@ -35,7 +35,11 @@ pub async fn send_envelope<T: CdrsTransport + 'static, CM: ConnectionManager<T> 
                         }
                     }
                 },
-                Err(error) => return Some(Err(error)),
+                Err(error) => {
+                    eprintln!("Trasport error: {:?}; for node {:?}", error,node);
+                    node.set_state_to_unknown();
+                    continue 'next_node;
+                }
             }
         }
     }

--- a/cdrs-tokio/src/cluster/topology/node.rs
+++ b/cdrs-tokio/src/cluster/topology/node.rs
@@ -154,7 +154,7 @@ impl<T: CdrsTransport, CM: ConnectionManager<T>> Node<T, CM> {
 
     #[inline]
     pub fn set_state_to_unknown(&self) {
-        self.state.store(NodeState::Unknown,Ordering::Relaxed);
+        self.state.store(NodeState::Unknown, Ordering::Relaxed);
     }
 
     /// The host ID that is assigned to this node by Cassandra. This value can be used to uniquely

--- a/cdrs-tokio/src/cluster/topology/node.rs
+++ b/cdrs-tokio/src/cluster/topology/node.rs
@@ -152,6 +152,11 @@ impl<T: CdrsTransport, CM: ConnectionManager<T>> Node<T, CM> {
         self.state.load(Ordering::Relaxed)
     }
 
+    #[inline]
+    pub fn set_state_to_unknown(&self) {
+        self.state.store(NodeState::Unknown,Ordering::Relaxed);
+    }
+
     /// The host ID that is assigned to this node by Cassandra. This value can be used to uniquely
     /// identify a node even when the underling IP address changes.
     #[inline]


### PR DESCRIPTION
Regard https://github.com/krojew/cdrs-tokio/issues/158
This temp solution will set the timed out node to unknown.
However, I don't think there is a mechanism to set it back to UP when it is ready. If this is the case, there could be a scenario where all nodes set to unknown and ignored.