### PR TITLE
Update deps

### DIFF
--- a/cassandra-protocol/Cargo.toml
+++ b/cassandra-protocol/Cargo.toml
@@ -26,7 +26,7 @@ float_eq = "1.0.0"
 integer-encoding = "4.0.0"
 itertools.workspace = true
 num = "0.4.0"
-lz4_flex = "0.10.0"
+lz4_flex = "0.11.0"
 snap = "1.0.5"
 thiserror.workspace = true
 time = { version = "0.3.9", features = ["std", "macros"] }

--- a/cassandra-protocol/src/compression.rs
+++ b/cassandra-protocol/src/compression.rs
@@ -257,9 +257,9 @@ mod tests {
     }
 
     #[test]
-    fn test_compression_encode_lz4_with_invalid_input() {
+    fn test_compression_decode_lz4_with_invalid_input() {
         let lz4_compression = Compression::Lz4;
-        let decode = lz4_compression.decode(vec![0, 0, 0, 0x7f, 0]);
+        let decode = lz4_compression.decode(vec![0, 0, 0, 0x7f]);
         assert!(decode.is_err());
     }
 

--- a/cdrs-tokio/Cargo.toml
+++ b/cdrs-tokio/Cargo.toml
@@ -20,7 +20,8 @@ http-proxy = ["async-http-proxy"]
 
 [dependencies]
 arc-swap.workspace = true
-atomic = "0.5.1"
+atomic = "0.6.0"
+bytemuck = { version = "1.13.1", features = ["derive"] }
 bytes.workspace = true
 cassandra-protocol = { path = "../cassandra-protocol", version = "3.1.0" }
 cdrs-tokio-helpers-derive = { path = "../cdrs-tokio-helpers-derive", version = "5.0.2", optional = true }

--- a/cdrs-tokio/src/cluster/connection_pool.rs
+++ b/cdrs-tokio/src/cluster/connection_pool.rs
@@ -1,4 +1,5 @@
 use atomic::Atomic;
+use bytemuck::NoUninit;
 use cassandra_protocol::frame::{Envelope, Version};
 use cassandra_protocol::query::utils::quote;
 use derive_more::Display;
@@ -21,7 +22,8 @@ use crate::error::{Error, Result as CdrsResult};
 use crate::retry::{ReconnectionPolicy, ReconnectionSchedule};
 use crate::transport::CdrsTransport;
 
-#[derive(Copy, Clone, PartialEq, Eq, Display)]
+#[derive(Copy, Clone, PartialEq, Eq, Display, NoUninit)]
+#[repr(u8)]
 enum ReconnectionState {
     NotRunning,
     InProgress,

--- a/cdrs-tokio/src/cluster/topology/node_state.rs
+++ b/cdrs-tokio/src/cluster/topology/node_state.rs
@@ -1,7 +1,9 @@
+use bytemuck::NoUninit;
 use derive_more::Display;
 
 /// The state of a node, as viewed from the driver.
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display, NoUninit)]
+#[repr(u8)]
 pub enum NodeState {
     /// The driver has never tried to connect to the node, nor received any topology events about it.
     ///


### PR DESCRIPTION
Supercedes https://github.com/krojew/cdrs-tokio/pull/167 and https://github.com/krojew/cdrs-tokio/pull/164

For some reason the input in `test_compression_decode_lz4_with_invalid_input` no longer triggers an error from lz4_flex, instead it now returns `Ok(vec![])`.
so I just adjusted the input a little and it gives an error again now.

`Atomic<T>` now requires that T implements `bytemuck::NoUninit`.
I assume that previously `Atomic` was previously unsound in some cases and now they have introduced this requirement to ensure soundness.
To implement `NoUninit` I used bytemuck's derive macros which will fail to compile if the type cannot soundly implement `NoUninit`