### PR TITLE
Vector support

### DIFF
--- a/cassandra-protocol/src/types.rs
+++ b/cassandra-protocol/src/types.rs
@@ -30,6 +30,7 @@ pub mod rows;
 pub mod tuple;
 pub mod udt;
 pub mod value;
+pub mod vector;
 
 pub mod prelude {
     pub use crate::error::{Error, Result};

--- a/cassandra-protocol/src/types/cassandra_type.rs
+++ b/cassandra-protocol/src/types/cassandra_type.rs
@@ -102,7 +102,7 @@ pub mod wrappers {
             } = get_vector_type_info(value).unwrap();
 
             if let Some(actual_bytes) = bytes.as_slice() {
-                let vector = decode_vector(actual_bytes, version, count)
+                let vector = decode_float_vector(actual_bytes, version, count)
                     .map(|data| Some(Vector::new(col_type.clone(), data, version)))
                     .expect("could not decode vector")
                     .unwrap()

--- a/cassandra-protocol/src/types/data_serialization_types.rs
+++ b/cassandra-protocol/src/types/data_serialization_types.rs
@@ -151,7 +151,7 @@ pub fn decode_list(bytes: &[u8], version: Version) -> Result<Vec<CBytes>, io::Er
     Ok(list)
 }
 
-pub fn decode_vector(
+pub fn decode_float_vector(
     bytes: &[u8],
     _version: Version,
     count: usize,

--- a/cassandra-protocol/src/types/data_serialization_types.rs
+++ b/cassandra-protocol/src/types/data_serialization_types.rs
@@ -151,6 +151,21 @@ pub fn decode_list(bytes: &[u8], version: Version) -> Result<Vec<CBytes>, io::Er
     Ok(list)
 }
 
+pub fn decode_vector(
+    bytes: &[u8],
+    _version: Version,
+    count: usize,
+) -> Result<Vec<CBytes>, io::Error> {
+    let type_size = 4;
+
+    let mut vector = Vec::with_capacity(count);
+    for i in (0..(count * type_size)).step_by(4) {
+        vector.push(CBytes::new(bytes[i..i + type_size].to_vec()));
+    }
+
+    Ok(vector)
+}
+
 // Decodes Cassandra `set` data (bytes)
 #[inline]
 pub fn decode_set(bytes: &[u8], version: Version) -> Result<Vec<CBytes>, io::Error> {

--- a/cassandra-protocol/src/types/vector.rs
+++ b/cassandra-protocol/src/types/vector.rs
@@ -1,0 +1,76 @@
+use crate::error::Result;
+use crate::frame::message_result::{ColType, ColTypeOption, ColTypeOptionValue};
+use crate::frame::Version;
+use crate::types::data_serialization_types::*;
+use crate::types::{AsRust, AsRustType, CBytes};
+use derive_more::Constructor;
+
+// TODO: consider using pointers to ColTypeOption and Vec<CBytes> instead of owning them.
+#[derive(Debug, Constructor)]
+pub struct Vector {
+    /// column spec of the list, i.e. id should be List as it's a list and value should contain
+    /// a type of list items.
+    metadata: ColTypeOption,
+    data: Vec<CBytes>,
+    protocol_version: Version,
+}
+
+impl Vector {
+    fn map<T, F>(&self, f: F) -> Vec<T>
+    where
+        F: FnMut(&CBytes) -> T,
+    {
+        self.data.iter().map(f).collect()
+    }
+}
+
+pub struct VectorInfo {
+    pub internal_type: String,
+    pub count: usize,
+}
+
+pub fn get_vector_type_info(option_value: &ColTypeOptionValue) -> Result<VectorInfo> {
+    let input = match option_value {
+        ColTypeOptionValue::CString(ref s) => s,
+        _ => panic!(),
+    };
+
+    let _custom_type = input.split('(').next().unwrap().rsplit('.').next().unwrap();
+
+    let vector_type = input
+        .split('(')
+        .nth(1)
+        .unwrap()
+        .split(',')
+        .next()
+        .unwrap()
+        .rsplit('.')
+        .next()
+        .unwrap()
+        .trim();
+
+    let count: usize = input
+        .split('(')
+        .nth(1)
+        .unwrap()
+        .rsplit(',')
+        .next()
+        .unwrap()
+        .split(')')
+        .next()
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+
+    Ok(VectorInfo {
+        internal_type: vector_type.to_string(),
+        count,
+    })
+}
+
+impl AsRust for Vector {}
+
+vector_as_rust!(f32);
+
+vector_as_cassandra_type!();

--- a/cassandra-protocol/src/types/vector.rs
+++ b/cassandra-protocol/src/types/vector.rs
@@ -1,4 +1,4 @@
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::frame::message_result::{ColType, ColTypeOption, ColTypeOptionValue};
 use crate::frame::Version;
 use crate::types::data_serialization_types::*;
@@ -32,7 +32,7 @@ pub struct VectorInfo {
 pub fn get_vector_type_info(option_value: &ColTypeOptionValue) -> Result<VectorInfo> {
     let input = match option_value {
         ColTypeOptionValue::CString(ref s) => s,
-        _ => panic!(),
+        _ => return Err(Error::General("option value must be a string".into())),
     };
 
     let _custom_type = input.split('(').next().unwrap().rsplit('.').next().unwrap();


### PR DESCRIPTION
This PR adds support for decoding Cassandra v5's new `VECTOR` types. 

https://cassandra.apache.org/_/blog/Apache-Cassandra-5.0-Features-Vector-Search.html