### PR TITLE
Remove unneeded deps

### DIFF
--- a/cassandra-protocol/Cargo.toml
+++ b/cassandra-protocol/Cargo.toml
@@ -16,7 +16,6 @@ e2e-tests = []
 
 [dependencies]
 arc-swap.workspace = true
-arrayref = "0.3.7"
 bitflags = "2.5.0"
 chrono = { version = "0.4.31", default_features = false, features = ["std"] }
 crc32fast = "1.4.0"
@@ -25,10 +24,10 @@ derive_more.workspace = true
 float_eq = "1.0.1"
 integer-encoding = "4.0.0"
 itertools.workspace = true
-num = "0.4.1"
+num-bigint = "0.4.1"
 lz4_flex = "0.11.1"
 snap = "1.1.0"
 thiserror.workspace = true
-time = { version = "0.3.29", features = ["std", "macros"] }
+time = { version = "0.3.29", features = ["macros"] }
 uuid.workspace = true
 bytes.workspace = true

--- a/cassandra-protocol/src/frame/traits.rs
+++ b/cassandra-protocol/src/frame/traits.rs
@@ -1,7 +1,7 @@
 use crate::error;
 use crate::frame::Version;
 use crate::query;
-use num::BigInt;
+use num_bigint::BigInt;
 use std::io::{Cursor, Write};
 
 /// Trait that should be implemented by all types that wish to be serialized to a buffer.

--- a/cassandra-protocol/src/types.rs
+++ b/cassandra-protocol/src/types.rs
@@ -497,7 +497,7 @@ pub fn cursor_next_value_ref<'a>(
 mod tests {
     use super::*;
     use crate::frame::traits::FromCursor;
-    use num::BigInt;
+    use num_bigint::BigInt;
     use std::io::Cursor;
 
     fn from_i_bytes(bytes: &[u8]) -> i64 {

--- a/cassandra-protocol/src/types/cassandra_type.rs
+++ b/cassandra-protocol/src/types/cassandra_type.rs
@@ -1,4 +1,4 @@
-use num::BigInt;
+use num_bigint::BigInt;
 use std::collections::HashMap;
 use std::net::IpAddr;
 

--- a/cassandra-protocol/src/types/decimal.rs
+++ b/cassandra-protocol/src/types/decimal.rs
@@ -1,6 +1,6 @@
 use derive_more::Constructor;
 use float_eq::*;
-use num::BigInt;
+use num_bigint::BigInt;
 use std::io::Cursor;
 
 use crate::frame::{Serialize, Version};

--- a/cassandra-protocol/src/types/list.rs
+++ b/cassandra-protocol/src/types/list.rs
@@ -1,5 +1,5 @@
 use derive_more::Constructor;
-use num::BigInt;
+use num_bigint::BigInt;
 use std::net::IpAddr;
 use uuid::Uuid;
 

--- a/cassandra-protocol/src/types/map.rs
+++ b/cassandra-protocol/src/types/map.rs
@@ -13,7 +13,7 @@ use crate::types::list::List;
 use crate::types::tuple::Tuple;
 use crate::types::udt::Udt;
 use crate::types::{AsRust, AsRustType, CBytes};
-use num::BigInt;
+use num_bigint::BigInt;
 
 #[derive(Debug)]
 pub struct Map {

--- a/cassandra-protocol/src/types/rows.rs
+++ b/cassandra-protocol/src/types/rows.rs
@@ -19,7 +19,7 @@ use crate::types::map::Map;
 use crate::types::tuple::Tuple;
 use crate::types::udt::Udt;
 use crate::types::{ByIndex, ByName, CBytes, IntoRustByIndex, IntoRustByName};
-use num::BigInt;
+use num_bigint::BigInt;
 
 #[derive(Clone, Debug)]
 pub struct Row {

--- a/cassandra-protocol/src/types/tuple.rs
+++ b/cassandra-protocol/src/types/tuple.rs
@@ -1,5 +1,5 @@
 use chrono::prelude::*;
-use num::BigInt;
+use num_bigint::BigInt;
 use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 use time::PrimitiveDateTime;

--- a/cassandra-protocol/src/types/udt.rs
+++ b/cassandra-protocol/src/types/udt.rs
@@ -16,7 +16,7 @@ use crate::types::list::List;
 use crate::types::map::Map;
 use crate::types::tuple::Tuple;
 use crate::types::{ByName, CBytes, IntoRustByName};
-use num::BigInt;
+use num_bigint::BigInt;
 
 #[derive(Clone, Debug)]
 pub struct Udt {

--- a/cassandra-protocol/src/types/value.rs
+++ b/cassandra-protocol/src/types/value.rs
@@ -7,7 +7,7 @@ use std::net::IpAddr;
 use std::num::{NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8};
 
 use chrono::prelude::*;
-use num::BigInt;
+use num_bigint::BigInt;
 use time::PrimitiveDateTime;
 use uuid::Uuid;
 


### PR DESCRIPTION
* arrayref is not needed, we can just create an array and convert that to the ip address.
* num is a meta crate that just reexports the crates that it uses. We can avoid a whole bunch of `num-*` subdependencies we dont need by just directly using num-bigint
  + this is not a breaking change since its actually the same type just accessed without the meta crate reexporting it.
* I removed "std" feature from time since time enables it by default anyway.