### PR TITLE
Fixed the race condition happening during full TCP reconnection

### DIFF
--- a/cdrs-tokio/src/cluster/connection_pool.rs
+++ b/cdrs-tokio/src/cluster/connection_pool.rs
@@ -369,6 +369,11 @@ impl<T: CdrsTransport + 'static, CM: ConnectionManager<T> + 'static> ConnectionP
                             if let Some(node) = node.upgrade() {
                                 debug!(?broadcast_rpc_address, "All connections reestablished.");
                                 node.mark_up();
+                            } else {
+                                debug!(
+                                    ?broadcast_rpc_address,
+                                    "Node is discarded during reconnection."
+                                );
                             }
                         } else if let Some(pool) = pool.upgrade() {
                             if pool.is_any_connection_up().await {

--- a/cdrs-tokio/src/cluster/topology/node.rs
+++ b/cdrs-tokio/src/cluster/topology/node.rs
@@ -194,6 +194,8 @@ impl<T: CdrsTransport, CM: ConnectionManager<T>> Node<T, CM> {
         let pool = self
             .connection_pool
             .get_or_try_init(|| {
+                debug!(?self.host_id, "Creating connection pool");
+
                 self.connection_pool_factory.create(
                     self.distance.unwrap_or(NodeDistance::Remote),
                     self.broadcast_rpc_address,


### PR DESCRIPTION
Issue description: https://github.com/krojew/cdrs-tokio/issues/198

Why this approach works:
- in control_connection.rs, when no nodes are available for load balancing, we fallback to configured URLs considering that all nodes in LB are dead anyway
- though, in `refresh_metadata()`, we work with them like they were still valid, which leads to the situations when we had only `Down` nodes in LB forever
- but if we call the `build_initial_metadata` method instead, we will not reuse nodes, all of which are down, and create fresh living instances instead

Tested locally a few times, but none of the files with changes has any unit tests to fix the behaviour