### PR TITLE
Replace lazy_static crate with std library's LazyLock

### DIFF
--- a/cdrs-tokio/Cargo.toml
+++ b/cdrs-tokio/Cargo.toml
@@ -29,7 +29,6 @@ derivative.workspace = true
 futures = { version = "0.3.28", default-features = false, features = ["alloc"] }
 fxhash = "0.2.1"
 itertools.workspace = true
-lazy_static = "1.4.0"
 rand = "0.9.0"
 serde_json = "1.0.107"
 thiserror.workspace = true
@@ -50,7 +49,6 @@ features = ["runtime-tokio", "basic-auth"]
 float_eq = "1.0.1"
 maplit = "1.0.2"
 mockall = "0.13.0"
-lazy_static = "1.4.0"
 regex = "1.10.4"
 uuid = { version = "1.4.1", features = ["v4"] }
 time = { version = "0.3.29", features = ["std", "macros"] }

--- a/cdrs-tokio/src/cluster/session.rs
+++ b/cdrs-tokio/src/cluster/session.rs
@@ -15,11 +15,10 @@ use derivative::Derivative;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
-use lazy_static::lazy_static;
 use std::io::{Cursor, Write};
 use std::marker::PhantomData;
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use thiserror::Error;
 use tokio::sync::broadcast::{channel, Receiver, Sender};
 use tokio::sync::watch;
@@ -61,9 +60,8 @@ use crate::transport::{CdrsTransport, TransportTcp};
 pub const DEFAULT_TRANSPORT_BUFFER_SIZE: usize = 1024;
 const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 128;
 
-lazy_static! {
-    static ref DEFAULT_STATEMET_PARAMETERS: StatementParams = Default::default();
-}
+static DEFAULT_STATEMENT_PARAMETERS: LazyLock<StatementParams> =
+    LazyLock::new(|| Default::default());
 
 #[inline]
 fn convert_to_prepared(body: ResponseBody) -> error::Result<BodyResResultPrepared> {
@@ -406,7 +404,7 @@ impl<
     /// Executes given prepared query.
     #[inline]
     pub async fn exec(&self, prepared: &PreparedQuery) -> error::Result<Envelope> {
-        self.exec_with_params(prepared, &DEFAULT_STATEMET_PARAMETERS)
+        self.exec_with_params(prepared, &DEFAULT_STATEMENT_PARAMETERS)
             .await
     }
 
@@ -476,7 +474,7 @@ impl<
     /// Executes batch query.
     #[inline]
     pub async fn batch(&self, batch: QueryBatch) -> error::Result<Envelope> {
-        self.batch_with_params(batch, &DEFAULT_STATEMET_PARAMETERS)
+        self.batch_with_params(batch, &DEFAULT_STATEMENT_PARAMETERS)
             .await
     }
 
@@ -512,7 +510,7 @@ impl<
     /// Executes a query.
     #[inline]
     pub async fn query<Q: ToString>(&self, query: Q) -> error::Result<Envelope> {
-        self.query_with_params(query, DEFAULT_STATEMET_PARAMETERS.clone())
+        self.query_with_params(query, DEFAULT_STATEMENT_PARAMETERS.clone())
             .await
     }
 

--- a/cdrs-tokio/src/cluster/token_map.rs
+++ b/cdrs-tokio/src/cluster/token_map.rs
@@ -110,9 +110,8 @@ impl<T: CdrsTransport, CM: ConnectionManager<T>> TokenMap<T, CM> {
 mod tests {
     use cassandra_protocol::frame::Version;
     use itertools::Itertools;
-    use lazy_static::lazy_static;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-    use std::sync::Arc;
+    use std::sync::{Arc, LazyLock};
     use tokio::sync::watch;
     use uuid::Uuid;
 
@@ -124,11 +123,9 @@ mod tests {
     use crate::retry::MockReconnectionPolicy;
     use crate::transport::MockCdrsTransport;
 
-    lazy_static! {
-        static ref HOST_ID_1: Uuid = Uuid::new_v4();
-        static ref HOST_ID_2: Uuid = Uuid::new_v4();
-        static ref HOST_ID_3: Uuid = Uuid::new_v4();
-    }
+    static HOST_ID_1: LazyLock<Uuid> = LazyLock::new(|| Uuid::new_v4());
+    static HOST_ID_2: LazyLock<Uuid> = LazyLock::new(|| Uuid::new_v4());
+    static HOST_ID_3: LazyLock<Uuid> = LazyLock::new(|| Uuid::new_v4());
 
     fn prepare_nodes() -> NodeMap<MockCdrsTransport, MockConnectionManager<MockCdrsTransport>> {
         let (_, keyspace_receiver) = watch::channel(None);

--- a/cdrs-tokio/src/load_balancing/topology_aware.rs
+++ b/cdrs-tokio/src/load_balancing/topology_aware.rs
@@ -302,9 +302,8 @@ impl<T: CdrsTransport, CM: ConnectionManager<T>> TopologyAwareLoadBalancingStrat
 mod tests {
     use cassandra_protocol::frame::Version;
     use fxhash::FxHashMap;
-    use lazy_static::lazy_static;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-    use std::sync::Arc;
+    use std::sync::{Arc, LazyLock};
     use tokio::sync::watch;
     use uuid::Uuid;
 
@@ -321,13 +320,11 @@ mod tests {
     use crate::retry::MockReconnectionPolicy;
     use crate::transport::MockCdrsTransport;
 
-    lazy_static! {
-        static ref HOST_ID_1: Uuid = Uuid::new_v4();
-        static ref HOST_ID_2: Uuid = Uuid::new_v4();
-        static ref HOST_ID_3: Uuid = Uuid::new_v4();
-        static ref HOST_ID_4: Uuid = Uuid::new_v4();
-        static ref HOST_ID_5: Uuid = Uuid::new_v4();
-    }
+    static HOST_ID_1: LazyLock<Uuid> = LazyLock::new(|| Uuid::new_v4());
+    static HOST_ID_2: LazyLock<Uuid> = LazyLock::new(|| Uuid::new_v4());
+    static HOST_ID_3: LazyLock<Uuid> = LazyLock::new(|| Uuid::new_v4());
+    static HOST_ID_4: LazyLock<Uuid> = LazyLock::new(|| Uuid::new_v4());
+    static HOST_ID_5: LazyLock<Uuid> = LazyLock::new(|| Uuid::new_v4());
 
     fn create_cluster(
     ) -> ClusterMetadata<MockCdrsTransport, MockConnectionManager<MockCdrsTransport>> {


### PR DESCRIPTION
LazyLock was introduced in rust 1.80 from Aug 2024 and the latest release is rust 1.85
cdrs-tokio doesnt conform to any particular MSRV but 5 releases seems like a reasonable grace period.

All usages are equivalent but we now avoid the use of macros and avoid an extra dependency.