### PR TITLE
Use try_send to prevent lock of sending errors

### DIFF
--- a/cdrs-tokio/src/cluster/connection_pool.rs
+++ b/cdrs-tokio/src/cluster/connection_pool.rs
@@ -488,17 +488,8 @@ impl<T: CdrsTransport + 'static, CM: ConnectionManager<T>> ConnectionPool<T, CM>
             match error_sender.try_send(Error::General(
                 "Not all pool connections could be established!".to_string(),
             )) {
-                Ok(()) => {
-                    // Sent successfully
-                }
-                Err(mpsc::error::TrySendError::Full(_)) => {
-                    // Channel is full, maybe log or retry
-                    warn!("Error channel is full, could not send error notification.");
-                }
-                Err(mpsc::error::TrySendError::Closed(_)) => {
-                    // Channel is closed, log or handle accordingly
-                    warn!("Error channel is closed, could not send error notification.");
-                }
+                Ok(_) => debug!("Error handler notified!"),
+                Err(e) => warn!("Error handler failed to notify: {e}"),
             }
         }
 

--- a/cdrs-tokio/src/transport.rs
+++ b/cdrs-tokio/src/transport.rs
@@ -398,7 +398,10 @@ impl AsyncTransport {
             response_handler_map.signal_general_error(&error);
 
             if let Some(error_handler) = error_handler {
-                let _ = error_handler.send(error).await;
+                match error_handler.try_send(error) {
+                    Ok(_) => debug!("Error handler notified!"),
+                    Err(e) => warn!("Error handler failed to notify: {e}"),
+                }
             }
         }
     }


### PR DESCRIPTION
If getting TCP error in transport.rs, the code will stuck at sending errors to error_sender.
Use try_send instead to prevent this from happening.